### PR TITLE
Improved build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ python:
   - "pypy3"
 env:
   - DJANGO="Django>=1.4,<1.5"
-  - DJANGO="django>=1.5,<1.6"
-  - DJANGO="django>=1.6,<1.7"
-  - DJANGO="django>=1.7,<1.8"
+  - DJANGO="Django>=1.5,<1.6"
+  - DJANGO="Django>=1.6,<1.7"
+  - DJANGO="Django>=1.7,<1.8"
 install:
   - travis_retry pip install -q $DJANGO
   - python setup.py develop


### PR DESCRIPTION
Added Python 3.4, PyPy and PyPy 3 to the build matrix.
Added Django 1.6 and 1.7 to the build matrix.
pip deprecated --use-mirrors. Instead we should use travis_retry in order to avoid failing the build due to network errors.
The build should fast finish since the matrix is large.
