### PR TITLE
Bug - Filters which have a different filter name from the model field name have the model field name when used in a RelatedFilter

### DIFF
--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -90,7 +90,7 @@ class FilterSet(django_filters.FilterSet):
                         return True
             return False
 
-        for (filter_key, filter_value) in filterset.base_filters.iteritems():
+        for (filter_key, filter_value) in filterset.base_filters.items():
             if _should_skip():
                 continue
 

--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -78,30 +78,31 @@ class FilterSet(django_filters.FilterSet):
         """
         def _should_skip():
             for name, filter_ in six.iteritems(self.filters):
-                if f == filter_:
+                if filter_value == filter_:
                     return True
                 # Avoid infinite recursion on recursive relations.  If the queryset and
                 # class are the same, then we assume that we've already added this
                 # filter previously along the lookup chain, e.g.
                 # a__b__a <-- the last 'a' there.
                 if (isinstance(filter_, filters.RelatedFilter) and
-                    isinstance(f, filters.RelatedFilter)):
-                    if f.extra.get('queryset', None) == filter_.extra.get('queryset'):
+                    isinstance(filter_value, filters.RelatedFilter)):
+                    if filter_value.extra.get('queryset', None) == filter_.extra.get('queryset'):
                         return True
             return False
 
-        for f in filterset.base_filters.values():
+        for (filter_key, filter_value) in filterset.base_filters.iteritems():
             if _should_skip():
                 continue
-    
-            f = copy(f)
+
+            filter_value = copy(filter_value)
 
             # Guess on the field to join on, if applicable
-            if not getattr(f, 'parent_relation', None):
-                f.parent_relation = filterset._meta.model.__name__.lower()
+            if not getattr(filter_value, 'parent_relation', None):
+                filter_value.parent_relation = filterset._meta.model.__name__.lower()
 
             # We use filter_.name -- which is the internal name, to do the actual query
-            filter_name = f.name 
-            f.name = '%s%s%s' % (filter_.name, LOOKUP_SEP, filter_name)
-            # and then we use the /given/ name keyword as the actual querystring lookup.
-            self.filters['%s%s%s' % (name, LOOKUP_SEP, filter_name)] = f
+            filter_name = filter_value.name
+            filter_value.name = '%s%s%s' % (filter_.name, LOOKUP_SEP, filter_name)
+            # and then we use the /given/ name keyword as the actual querystring lookup, and
+            # the filter's name in the related class (filter_key).
+            self.filters['%s%s%s' % (name, LOOKUP_SEP, filter_key)] = filter_value

--- a/rest_framework_filters/tests.py
+++ b/rest_framework_filters/tests.py
@@ -162,6 +162,20 @@ class BlogPostFilter(FilterSet):
         model = BlogPost
 
 
+class UserFilterWithDifferentName(FilterSet):
+    name = filters.CharFilter(name='username')
+
+    class Meta:
+        model = User
+
+
+class NoteFilterWithRelatedDifferentName(FilterSet):
+    author = RelatedFilter(UserFilterWithDifferentName, name='author')
+
+    class Meta:
+        model = Note
+
+
 #############################################################
 # Recursive filtersets
 #############################################################
@@ -498,6 +512,16 @@ class TestFilterSets(TestCase):
         }
         f = NoteFilterWithRelatedAllDifferentFilterName(GET, queryset=Note.objects.all())
         self.assertEqual(len(list(f)), 4)
+
+    def test_relatedfilter_different_name(self):
+        # Test the name filter on the related UserFilter set.
+        GET = {
+            'author__name': 'user2',
+        }
+        f = NoteFilterWithRelatedDifferentName(GET, queryset=Note.objects.all())
+        self.assertEqual(len(list(f)), 1)
+        note = list(f)[0]
+        self.assertEqual(note.title, "Hello Test 4")
 
     def test_double_relation_filter(self):
         GET = {


### PR DESCRIPTION
My use case was :

```
class UserFilter(filters.FilterSet):
	max_date_joined = filters.DateFilter(name='date_joined', lookup_type='lte')
    	min_date_joined = filters.DateFilter(name='date_joined', lookup_type='gte')
	date_joined = filters.DateFilter(name='date_joined', lookup_type='contains')


class OtherFilter(filters.FilterSet):
	user = filters.RelatedFilter(UserFilter, name='user')
```

and I couldn't filter by user__max_date_joined or user__min_date_joined : both were ignored (as if the filter was missing).

I looked at self.filters after ```FilterSet.__init__``` and found out self.filters only had a user__date_joined entry (no user__min_date_joined or user__max_date_joined). This then led me to 
discover populate_from_filterset() used f.name (which was date_joined in all three cases) instead of the "filter name in the related FilterSet" (filter_key in my diff).
