### PR TITLE
django 1.8 RelatedObject

### DIFF
--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -9,8 +9,11 @@ except ImportError:  # pragma: nocover
     # Django < 1.5 fallback
     from django.db.models.sql.constants import LOOKUP_SEP  # noqa
 from django.db import models
-from django.utils.datastructures import SortedDict
-from django.db.models.related import RelatedObject
+try:
+    from django.db.models.related import RelatedObject as ForeignObjectRel
+except ImportError:  # pragma: nocover
+    # Django >= 1.8 replaces RelatedObject with ForeignObjectRel
+    from django.db.models.fields.related import ForeignObjectRel
 from django.utils import six
 
 import django_filters
@@ -55,7 +58,7 @@ class FilterSet(django_filters.FilterSet):
                 model = self._meta.model
                 field = get_model_field(model, filter_.name)
                 for lookup_type in self.LOOKUP_TYPES:
-                    if isinstance(field, RelatedObject):
+                    if isinstance(field, ForeignObjectRel):
                         f = self.filter_for_reverse_field(field, filter_.name)
                     else:
                         f = self.filter_for_field(field, filter_.name)


### PR DESCRIPTION
RelatedObject is deprecated in django 1.8 ([docs](https://docs.djangoproject.com/en/dev/releases/1.8/#model-attribute-on-private-model-relations))

This pull request is handling the problem