### PR TITLE
Use django-filter IsoDateTimeFilter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ env:
   - DJANGO="Django>=1.8,<1.9"
 install:
   - travis_retry pip install -q $DJANGO
-  - pip install py-dateutil
   - python setup.py install
 script: python manage.py test rest_framework_filters
 

--- a/rest_framework_filters/fields.py
+++ b/rest_framework_filters/fields.py
@@ -1,5 +1,11 @@
 from django import forms
 
+
+# https://code.djangoproject.com/ticket/19917
+class Django14TimeField(forms.TimeField):
+    input_formats = ['%H:%M:%S', '%H:%M:%S.%f', '%H:%M']
+
+
 class ArrayDecimalField(forms.DecimalField):
     def clean(self, value):
         if value is None:

--- a/rest_framework_filters/filters.py
+++ b/rest_framework_filters/filters.py
@@ -2,41 +2,9 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from django.utils import six
-
-from rest_framework.settings import api_settings
-import rest_framework.filters
-import django_filters
 from django_filters.filters import *
 
 from . import fields
-
-def subsitute_iso8601(date_type):
-    from rest_framework import ISO_8601
-
-    if date_type == 'datetime':
-        strptime_iso8601 = '%Y-%m-%dT%H:%M:%S.%f'
-        formats = api_settings.DATETIME_INPUT_FORMATS
-    elif date_type == 'date':
-        strptime_iso8601 = '%Y-%m-%d'
-        formats = api_settings.DATE_INPUT_FORMATS
-    elif date_type == 'time':
-        strptime_iso8601 = '%H:%M:%S.%f'
-        formats = api_settings.TIME_INPUT_FORMATS
-
-    new_formats = []
-    for f in formats:
-        if f == ISO_8601:
-            new_formats.append(strptime_iso8601)
-        else:
-            new_formats.append(f)
-    return new_formats
-
-
-# In order to support ISO-8601 -- which is the default output for
-# DRF -- we need to set up custom date/time input formats.
-TIME_INPUT_FORMATS = subsitute_iso8601('time')
-DATE_INPUT_FORMATS = subsitute_iso8601('date')
-DATETIME_INPUT_FORMATS = subsitute_iso8601('datetime')
 
 
 class RelatedFilter(ModelChoiceFilter):
@@ -50,7 +18,7 @@ class RelatedFilter(ModelChoiceFilter):
             # This is a recursive relation, defined via a string, so we need
             # to create and import the class here.
             items = self.filterset.split('.')
-            cls = str(items[-1]) # Ensure not unicode on py2.x
+            cls = str(items[-1])  # Ensure not unicode on py2.x
             mod = __import__('.'.join(items[:-1]), fromlist=[cls])
             self.filterset = getattr(mod, cls)
 
@@ -64,24 +32,6 @@ class AllLookupsFilter(Filter):
 ###################################################
 # Fixed-up versions of some of the default filters
 ###################################################
-
-class DateFilter(django_filters.DateFilter):
-    def __init__(self, *args, **kwargs):
-        super(DateFilter, self).__init__(*args, **kwargs)
-        self.extra.update({'input_formats': DATE_INPUT_FORMATS})
-
-
-class DateTimeFilter(django_filters.DateTimeFilter):
-    def __init__(self, *args, **kwargs):
-        super(DateTimeFilter, self).__init__(*args, **kwargs)
-        self.extra.update({'input_formats': DATETIME_INPUT_FORMATS})
-
-
-class TimeFilter(django_filters.DateTimeFilter):
-    def __init__(self, *args, **kwargs):
-        super(TimeFilter, self).__init__(*args, **kwargs)
-        self.extra.update({'input_formats': TIME_INPUT_FORMATS})
-
 
 class InSetNumberFilter(NumberFilter):
     field_class = fields.ArrayDecimalField

--- a/rest_framework_filters/filters.py
+++ b/rest_framework_filters/filters.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import django
 from django.utils import six
 from django_filters.filters import *
 
@@ -32,6 +33,11 @@ class AllLookupsFilter(Filter):
 ###################################################
 # Fixed-up versions of some of the default filters
 ###################################################
+
+class TimeFilter(TimeFilter):
+    if django.VERSION < (1, 6):
+        field_class = fields.Django14TimeField
+
 
 class InSetNumberFilter(NumberFilter):
     field_class = fields.ArrayDecimalField

--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -28,13 +28,7 @@ class FilterSet(django_filters.FilterSet):
     # DRF -- we need to set up custom date/time input formats.
     filter_overrides = {
         models.DateTimeField: {
-            'filter_class': filters.DateTimeFilter,
-        }, 
-        models.DateField: {
-            'filter_class': filters.DateFilter,
-        }, 
-        models.TimeField: {
-            'filter_class': filters.TimeFilter,
+            'filter_class': filters.IsoDateTimeFilter,
         },
     }
 
@@ -68,7 +62,7 @@ class FilterSet(django_filters.FilterSet):
 
     def fix_filter_field(self, f):
         """
-        Fix the filter field based on the lookup type. 
+        Fix the filter field based on the lookup type.
         """
         lookup_type = f.lookup_type
         if lookup_type == 'isnull':

--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -24,12 +24,19 @@ from . import filters
 
 
 class FilterSet(django_filters.FilterSet):
-    # In order to support ISO-8601 -- which is the default output for
-    # DRF -- we need to set up custom date/time input formats.
     filter_overrides = {
+
+        # In order to support ISO-8601 -- which is the default output for
+        # DRF -- we need to use django-filter's IsoDateTimeFilter
         models.DateTimeField: {
             'filter_class': filters.IsoDateTimeFilter,
         },
+
+        # Django < 1.6 time input formats did not account for microseconds
+        # https://code.djangoproject.com/ticket/19917
+        models.TimeField: {
+            'filter_class': filters.TimeFilter,
+        }
     }
 
     LOOKUP_TYPES = django_filters.filters.LOOKUP_TYPES

--- a/rest_framework_filters/tests.py
+++ b/rest_framework_filters/tests.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 import time
 import datetime
 
-from dateutil.parser import parse as date_parse
+from django.utils.dateparse import parse_time, parse_datetime
 
 from django.db import models
 from django.test import TestCase
@@ -262,7 +262,7 @@ class TestFilterSets(TestCase):
         n.save()
 
         #######################
-        # Create notes 
+        # Create notes
         #######################
         n = Note(
             title="Test 2",
@@ -286,7 +286,7 @@ class TestFilterSets(TestCase):
         n.save()
 
         #######################
-        # Create posts 
+        # Create posts
         #######################
         post = Post(
             note=Note.objects.get(title="Test 1"),
@@ -360,7 +360,7 @@ class TestFilterSets(TestCase):
         )
         blogpost.save()
         blogpost.tags = [Tag.objects.get(name="house")]
-       
+
         ################################
         # Recursive relations
         ################################
@@ -600,10 +600,10 @@ class TestFilterSets(TestCase):
         date_str = JSONRenderer().render(data['date_joined']).decode('utf-8').strip('"')
 
         # Adjust for imprecise rendering of time
-        datetime_str = JSONRenderer().render(date_parse(data['datetime_joined']) + datetime.timedelta(seconds=0.6)).decode('utf-8').strip('"')
+        datetime_str = JSONRenderer().render(parse_datetime(data['datetime_joined']) + datetime.timedelta(seconds=0.6)).decode('utf-8').strip('"')
 
         # Adjust for imprecise rendering of time
-        dt = datetime.datetime.combine(datetime.date.today(), date_parse(data['time_joined']).time()) + datetime.timedelta(seconds=0.6)
+        dt = datetime.datetime.combine(datetime.date.today(), parse_time(data['time_joined'])) + datetime.timedelta(seconds=0.6)
         time_str = JSONRenderer().render(dt.time()).decode('utf-8').strip('"')
 
         # DateField


### PR DESCRIPTION
- replace py-dateutil with django.utils.dateparse
- remove custom date filter fields

Additionally, this may address #24, although we would need a testcase to verify. Either way, it follows the suggestion [here](https://github.com/philipn/django-rest-framework-filters/issues/24#issuecomment-106993504) to remove the custom definitions.