### PR TITLE
Use setUpTestData to improve test speed

### DIFF
--- a/rest_framework_filters/tests.py
+++ b/rest_framework_filters/tests.py
@@ -7,6 +7,7 @@ import datetime
 
 from dateutil.parser import parse as date_parse
 
+import django
 from django.db import models
 from django.test import TestCase
 from django.contrib.auth.models import User
@@ -238,7 +239,18 @@ class InSetLookupPersonFilter(FilterSet):
         model = Person
 
 class TestFilterSets(TestCase):
-    def setUp(self):
+
+    if django.VERSION >= (1, 8):
+        @classmethod
+        def setUpTestData(cls):
+            cls.generateTestData()
+
+    else:
+        def setUp(self):
+            self.generateTestData()
+
+    @classmethod
+    def generateTestData(cls):
         #######################
         # Create users
         #######################


### PR DESCRIPTION
Uses Django 1.8's setUpTestData to improve test run speed. When testing locally with Django 1.8, execution time dropped from 12.5 seconds to 1.25 seconds