### PR TITLE
Add `ALL_LOOKUPS` to filters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,6 +127,21 @@ and also filter on the default lookup (``exact``), as usual::
 
     /api/page/?title=The%20Park
 
+Additionally, you may use ``ALL_LOOKUPS`` with dictionary style declarations.
+
+.. code-block:: python
+
+    import rest_framework_filters as filters
+
+    class PageFilter(filters.FilterSet):
+        ...
+
+        class Meta:
+            fields = {
+                'title': filters.ALL_LOOKUPS,
+            }
+
+
 Combining RelatedFilter and AllLookupsFilter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/rest_framework_filters/filters.py
+++ b/rest_framework_filters/filters.py
@@ -6,8 +6,11 @@ from django.utils import six
 
 import django
 from django_filters.filters import *
+from django_filters.filters import LOOKUP_TYPES
 
 from . import fields
+
+ALL_LOOKUPS = LOOKUP_TYPES
 
 
 def _import_class(path):


### PR DESCRIPTION
Addresses, part of #9 by adding a convenient shorthand for adding all lookups to a dict-style declaration. Under the hood, `ALL_LOOKUPS` is just a reference to `django.db.models.sql.constants.QUERY_TERMS`, which is a list of all valid lookups.