### PR TITLE
Rework related filtering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.2"
   - "3.3"
   - "3.4"
+  - "3.5"
 env:
   - DJANGO="Django>=1.4,<1.5"
   - DJANGO="Django>=1.5,<1.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,12 @@ matrix:
       env: DJANGO="Django>=1.4,<1.5"
     - python: "3.4"
       env: DJANGO="Django>=1.4,<1.5"
+    - python: "3.5"
+      env: DJANGO="Django>=1.4,<1.5"
+    - python: "3.5"
+      env: DJANGO="Django>=1.5,<1.6"
+    - python: "3.5"
+      env: DJANGO="Django>=1.6,<1.7"
+    - python: "3.5"
+      env: DJANGO="Django>=1.7,<1.8"
   fast_finish: true

--- a/rest_framework_filters/backends.py
+++ b/rest_framework_filters/backends.py
@@ -1,50 +1,7 @@
-from copy import deepcopy
 
 import rest_framework.filters
-from rest_framework.compat import django_filters
-
 from .filterset import FilterSet
 
 
-
 class DjangoFilterBackend(rest_framework.filters.DjangoFilterBackend):
-    """
-    A version of `DjangoFilterBackend` that caches repeated filter classes
-    and uses our FilterSet by default.
-    """
     default_filter_set = FilterSet
-
-    _filter_instance_cache = {}
-
-    def _setup_filter_instance(self, _filter, query_params, queryset=None):
-        _filter.data = query_params or {}
-        _filter.is_bound = query_params is not None
-
-        if hasattr(_filter, '_qs'):
-            del _filter._qs
-        if hasattr(_filter, '_form'):
-            del _filter._form
-        if hasattr(_filter, '_ordering_field'):
-            del _filter._ordering_field
-
-        if queryset is None:
-            queryset = _filter._meta.model._default_manager.all()
-        _filter.queryset = queryset
-        # propagate the model being used through the filters
-        for f in _filter.filters.values():
-            f.model = _filter._meta.model
-
-    def filter_queryset(self, request, queryset, view):
-        filter_class = self.get_filter_class(view, queryset)
-
-        if filter_class:
-            if filter_class in self._filter_instance_cache:
-                _filter = self._filter_instance_cache[filter_class]
-                self._setup_filter_instance(_filter, request.query_params, queryset=queryset)
-            else:
-                _filter = filter_class(request.query_params, queryset=queryset)
-                self._filter_instance_cache[filter_class] = _filter
-
-            return _filter.qs
-
-        return queryset

--- a/rest_framework_filters/backends.py
+++ b/rest_framework_filters/backends.py
@@ -5,3 +5,13 @@ from .filterset import FilterSet
 
 class DjangoFilterBackend(rest_framework.filters.DjangoFilterBackend):
     default_filter_set = FilterSet
+    _related_filterset_cache = {}  # set to None to disable cache propagation
+
+    def filter_queryset(self, request, queryset, view):
+        filter_class = self.get_filter_class(view, queryset)
+
+        if filter_class:
+            cache = self._related_filterset_cache
+            return filter_class(request.query_params, queryset=queryset, cache=cache).qs
+
+        return queryset

--- a/rest_framework_filters/filters.py
+++ b/rest_framework_filters/filters.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+from collections import OrderedDict
 from django.utils import six
 
 from rest_framework.settings import api_settings
@@ -62,6 +63,27 @@ class RelatedFilter(ModelChoiceFilter):
 
         return locals()
     filterset = property(**filterset())
+
+    def get_filterset_subset(self, filter_names):
+        """
+        Returns a FilterSet subclass that contains the subset of filters
+        specified in `filter_names`. This is useful for creating FilterSets
+        used across relationships, as it minimizes the deepcopy overhead
+        incurred when instantiating the FilterSet.
+        """
+        BaseFilterSet = self.filterset
+
+        class FilterSetSubset(BaseFilterSet):
+            pass
+
+        FilterSetSubset.__name__ = str('%sSubset' % (BaseFilterSet.__name__))
+        FilterSetSubset.base_filters = OrderedDict([
+            (name, f)
+            for name, f in six.iteritems(BaseFilterSet.base_filters)
+            if name in filter_names
+        ])
+
+        return FilterSetSubset
 
     def setup_filterset(self):
         self.extra['queryset'] = self.filterset._meta.model.objects.all()

--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -29,7 +29,7 @@ class FilterSetMetaclass(filterset.FilterSetMetaclass):
 
         # Populate our FilterSet fields with all the possible
         # filters for the AllLookupsFilter field.
-        for name, filter_ in six.iteritems(new_class.base_filters):
+        for name, filter_ in six.iteritems(new_class.base_filters.copy()):
             if isinstance(filter_, filters.AllLookupsFilter):
                 model = new_class._meta.model
                 field = filterset.get_model_field(model, filter_.name)
@@ -74,7 +74,7 @@ class FilterSet(six.with_metaclass(FilterSetMetaclass, filterset.FilterSet)):
 
         super(FilterSet, self).__init__(*args, **kwargs)
 
-        for name, filter_ in six.iteritems(self.filters):
+        for name, filter_ in six.iteritems(self.filters.copy()):
             if isinstance(filter_, filters.RelatedFilter):
                 filter_.setup_filterset()
 

--- a/rest_framework_filters/tests.py
+++ b/rest_framework_filters/tests.py
@@ -669,3 +669,14 @@ class TestFilterSets(TestCase):
         self.assertEqual(len(f), 2)
         self.assertIn(p1, f)
         self.assertIn(p2, f)
+
+    def test_get_filterset_subset(self):
+        related_filter = NoteFilterWithRelated.base_filters['author']
+        filterset_class = related_filter.get_filterset_subset(['email'])
+
+        # ensure that the class name is useful when debugging
+        self.assertEqual(filterset_class.__name__, 'UserFilterSubset')
+
+        # ensure that the FilterSet subset only contains the requested fields
+        self.assertIn('email', filterset_class.base_filters)
+        self.assertEqual(len(filterset_class.base_filters), 1)


### PR DESCRIPTION
Hi. I spent some time reworking how related filtering was performed, which should fix #8. Wanted to discuss if this is worth merging back in, or if it should be spun out into a separate package.

For more context, there's a discussion with JockeTF  [here](https://github.com/rpkilby/django-rest-framework-filters/commit/b0f39b5bd707789d9ddb45b9e95f66cfde80b90d#commitcomment-13453459).

Happy to go into more depth, but in short:
- The implementation optimizes filter lookups by building filterset subclasses that only include the requested filters. (reduces a lot of overhead with initialization and deepcopy'ing filters, which is expensive apparently).
- These filterset subclasses are cached by the backend (instead of instances. This is relevant to the discussed race condition, which is not triggered).
- The AllLookupsFilter filter generation has been moved from filterset initialization into a metaclass, which turns it into a one-time cost.
- Filters are now bound to their parent filtersets, which affects filters such as MethodFilter.
- Ran some simple performance tests, with results posted in the above conversation. In short, the test combined an AllLookupsFilter with a RelatedFilter, and ran the filter 1000 times. 

    | django-filter | drf-filter | this pr |
    | ---------------- | ---------- | -------- |
    | 5.02237 s | 10.8006 s | 5.9353 s |

The one drawback is that the FilterSet is no longer able to generate a form that includes all of the filters from the related filtersets. However, I'm not sure if this is too much of an issue since the main use case is API filtering with DRF. Not sure if the form is really used here.