### PR TITLE
Ensure __import__ uses str in Python 2.X

### DIFF
--- a/rest_framework_filters/filters.py
+++ b/rest_framework_filters/filters.py
@@ -14,6 +14,7 @@ ALL_LOOKUPS = LOOKUP_TYPES
 
 def _import_class(path):
     module_path, class_name = path.rsplit('.', 1)
+    class_name = str(class_name) # Ensure not unicode on py2.x
     module = __import__(module_path, fromlist=[class_name], level=0)
     return getattr(module, class_name)
 


### PR DESCRIPTION
Similarly to what happened in #17, using `__import__` in Python 2.X passing a unicode string as the `fromlist` parameter raises this issue:

	. . .
 	       
	vi +61  ./rest_framework_filters/filters.py  # setup_filterset
	   self.extra['queryset'] = self.filterset._meta.model.objects.all()

	vi +30  ./rest_framework_filters/filters.py  # fget
	   self._filterset = _import_class(self._filterset)

	vi +17  ./rest_framework_filters/filters.py  # _import_class
	   module = __import__(module_path, fromlist=[class_name], level=0)

	TypeError: Item in ``from list'' not a string

This pull converts `class_name` to string, which is a no-op in Python 3.