### PR TITLE
Fix #49

### DIFF
--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -43,6 +43,9 @@ class FilterSetMetaclass(filterset.FilterSetMetaclass):
 
                     new_class.base_filters[filter_name] = f
 
+            elif name not in new_class.declared_filters:
+                new_class.base_filters[name] = new_class.fix_filter_field(filter_)
+
         return new_class
 
 

--- a/tests/filters.py
+++ b/tests/filters.py
@@ -176,3 +176,12 @@ class InSetLookupPersonNameFilter(FilterSet):
 
     class Meta:
         model = Person
+
+
+class BlogPostOverrideFilter(FilterSet):
+    declared_publish_date__isnull = filters.NumberFilter(name='publish_date', lookup_type='isnull')
+    all_declared_publish_date = filters.AllLookupsFilter(name='publish_date')
+
+    class Meta:
+        model = BlogPost
+        fields = {'publish_date': filters.ALL_LOOKUPS, }

--- a/tests/models.py
+++ b/tests/models.py
@@ -57,3 +57,4 @@ class BlogPost(models.Model):
     title = models.CharField(max_length=100)
     content = models.TextField()
     tags = models.ManyToManyField(Tag, null=True)
+    publish_date = models.DateField(null=True)

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -8,6 +8,8 @@ from django.test import TestCase, override_settings
 from django.contrib.auth.models import User
 from django.utils.dateparse import parse_time, parse_datetime
 
+from rest_framework_filters import filters
+
 from .models import (
     Note, Post, Cover, Page, A, B, C, Person, Tag, BlogPost,
 )
@@ -24,6 +26,7 @@ from .filters import (
     # PageFilterWithRelated,
     TagFilter,
     BlogPostFilter,
+    BlogPostOverrideFilter,
     # UserFilterWithDifferentName,
     NoteFilterWithRelatedDifferentName,
 
@@ -486,6 +489,30 @@ class FilterOverrideTests(TestCase):
         self.assertEqual(len(f), 2)
         self.assertIn(p1, f)
         self.assertIn(p2, f)
+
+    def test_declared_filters(self):
+        F = BlogPostOverrideFilter
+
+        # explicitly declared filters SHOULD NOT be overridden
+        self.assertIsInstance(
+            F.base_filters['declared_publish_date__isnull'],
+            filters.NumberFilter
+        )
+
+        # declared `AllLookupsFilter`s SHOULD generate filters that ARE overridden
+        self.assertIsInstance(
+            F.base_filters['all_declared_publish_date__isnull'],
+            filters.BooleanFilter
+        )
+
+    def test_dict_declaration(self):
+        F = BlogPostOverrideFilter
+
+        # dictionary style declared filters SHOULD be overridden
+        self.assertIsInstance(
+            F.base_filters['publish_date__isnull'],
+            filters.BooleanFilter
+        )
 
 
 class FilterExclusionTests(TestCase):


### PR DESCRIPTION
Ensures that dictionary style filter declarations are overridden by `fix_filter_field`