### PR TITLE
Add abstract CSV filter types

### DIFF
--- a/rest_framework_filters/fields.py
+++ b/rest_framework_filters/fields.py
@@ -11,23 +11,27 @@ class BooleanField(forms.BooleanField):
     widget = BooleanWidget
 
 
-class ArrayDecimalField(forms.DecimalField):
+class AbstractInField(object):
     def clean(self, value):
         if value is None:
             return None
 
         out = []
         for val in value.split(','):
-            out.append(super(ArrayDecimalField, self).clean(val))
+            out.append(super(AbstractInField, self).clean(val))
         return out
 
 
-class ArrayCharField(forms.CharField):
+class AbstractRangeField(object):
     def clean(self, value):
         if value is None:
             return None
 
+        vals = value.split(',')
+        if len(vals) != 2:
+            raise ValueError('Range query expects 2 values.')
+
         out = []
-        for val in value.split(','):
-            out.append(super(ArrayCharField, self).clean(val))
+        for val in vals:
+            out.append(super(AbstractRangeField, self).clean(val))
         return out

--- a/rest_framework_filters/fields.py
+++ b/rest_framework_filters/fields.py
@@ -29,7 +29,7 @@ class AbstractRangeField(object):
 
         vals = value.split(',')
         if len(vals) != 2:
-            raise ValueError('Range query expects 2 values.')
+            raise forms.ValidationError('Range query expects 2 values.')
 
         out = []
         for val in vals:

--- a/rest_framework_filters/filters.py
+++ b/rest_framework_filters/filters.py
@@ -73,7 +73,20 @@ class BooleanFilter(BooleanFilter):
     field_class = fields.BooleanField
 
 
-class InSetFilterBase(object):
+class AbstractCSVFilter(object):
+    """
+    Abstract base class for CSV type filters, such as IN and RANGE.
+    """
+    abstract_field_class = None
+
+    def __init__(self, *args, **kwargs):
+        super(AbstractCSVFilter, self).__init__(*args, **kwargs)
+
+        class ConcreteCSVField(self.abstract_field_class, self.field_class):
+            pass
+
+        self.field_class = ConcreteCSVField
+
     def filter(self, qs, value):
         if value in ([], (), {}, None, ''):
             return qs
@@ -84,12 +97,12 @@ class InSetFilterBase(object):
         return qs
 
 
-class InSetNumberFilter(InSetFilterBase, NumberFilter):
-    field_class = fields.ArrayDecimalField
+class AbstractInFilter(AbstractCSVFilter):
+    abstract_field_class = fields.AbstractInField
 
 
-class InSetCharFilter(InSetFilterBase, NumberFilter):
-    field_class = fields.ArrayCharField
+class AbstractRangeFilter(AbstractCSVFilter):
+    abstract_field_class = fields.AbstractRangeField
 
 
 class MethodFilter(Filter):

--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -189,8 +189,15 @@ class FilterSet(six.with_metaclass(FilterSetMetaclass, filterset.FilterSet)):
         lookup_type = f.lookup_type
         if lookup_type == 'isnull':
             return filters.BooleanFilter(name=("%s%sisnull" % (f.name, LOOKUP_SEP)))
-        if lookup_type == 'in' and type(f) == filters.NumberFilter:
-            return filters.InSetNumberFilter(name=("%s%sin" % (f.name, LOOKUP_SEP)))
-        if lookup_type == 'in' and type(f) == filters.CharFilter:
-            return filters.InSetCharFilter(name=("%s%sin" % (f.name, LOOKUP_SEP)))
+
+        if lookup_type == 'in':
+            class ConcreteInFilter(filters.AbstractInFilter, f.__class__):
+                pass
+            return ConcreteInFilter(name=("%s%sin" % (f.name, LOOKUP_SEP)))
+
+        if lookup_type == 'range':
+            class ConcreteRangeFilter(filters.AbstractRangeFilter, f.__class__):
+                pass
+            return ConcreteRangeFilter(name=("%s%srange" % (f.name, LOOKUP_SEP)))
+
         return f

--- a/tests/filters.py
+++ b/tests/filters.py
@@ -19,7 +19,7 @@ class NoteFilterWithAll(FilterSet):
 class UserFilter(FilterSet):
     username = filters.CharFilter(name='username')
     email = filters.CharFilter(name='email')
-    last_login = filters.AllLookupsFilter()
+    last_login = filters.AllLookupsFilter(name='last_login')
     is_active = filters.BooleanFilter(name='is_active')
 
     class Meta:


### PR DESCRIPTION
Add abstract CSV filters for IN and RANGE lookups. 
- fixes #2
- fixes #16 

RANGE and IN lookups should now be fixed for all field types. `fix_filter_field` derives a new filter class from the lookup filter (IN, RANGE) and the original type (CharFilter, NumberFilter). This way, we don't need to create filters for each data type.
