### PR TITLE
django-filter update

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,20 @@
 Unreleased
 ----------
 
+This release is tied to a major update of django-filter (more details in #66),
+which fixes how lookup expressions are resolved. 'in', 'range', and 'isnull'
+lookups no longer require special handling by django-rest-framework-filters.
+This has the following effects:
+
+  * Deprecates ArrayDecimalField/InSetNumberFilter
+  * Deprecates ArrayCharField/InSetCharFilter
+  * Deprecates FilterSet.fix_filter_field
+  * Deprecates ALL_LOOKUPS in favor of '__all__' constant.
+  * AllLookupsFilter now generates only valid lookup expressions.
+
+* #2 'range' lookup types do not work
+* #15 Date lookup types do not work (year, day, ...)
+* #16 'in' lookup types do not work
 * #64 Fix browsable API filter form
 * #69 Fix compatibility with base django-filter `FilterSet`s
 * #70 Refactor related filter handling, fixing some edge cases

--- a/rest_framework_filters/fields.py
+++ b/rest_framework_filters/fields.py
@@ -1,4 +1,7 @@
+
+import warnings
 from django import forms
+
 from django_filters.widgets import BooleanWidget
 
 
@@ -7,6 +10,14 @@ class BooleanField(forms.BooleanField):
 
 
 class ArrayDecimalField(forms.DecimalField):
+    def __init__(self, *args, **kwargs):
+        super(ArrayDecimalField, self).__init__(*args, **kwargs)
+        warnings.warn(
+            'ArrayDecimalField is deprecated and no longer necessary. See: '
+            'https://github.com/philipn/django-rest-framework-filters/issues/62',
+            DeprecationWarning, stacklevel=3
+        )
+
     def clean(self, value):
         if value is None:
             return None
@@ -18,6 +29,14 @@ class ArrayDecimalField(forms.DecimalField):
 
 
 class ArrayCharField(forms.CharField):
+    def __init__(self, *args, **kwargs):
+        super(ArrayCharField, self).__init__(*args, **kwargs)
+        warnings.warn(
+            'ArrayCharField is deprecated and no longer necessary. See: '
+            'https://github.com/philipn/django-rest-framework-filters/issues/62',
+            DeprecationWarning, stacklevel=3
+        )
+
     def clean(self, value):
         if value is None:
             return None

--- a/rest_framework_filters/filters.py
+++ b/rest_framework_filters/filters.py
@@ -4,11 +4,12 @@ from __future__ import unicode_literals
 from django.utils import six
 
 from django_filters.filters import *
-from django_filters.filters import LOOKUP_TYPES
 
 from . import fields
 
-ALL_LOOKUPS = LOOKUP_TYPES
+
+class ALL_LOOKUPS(object):
+    pass
 
 
 def _import_class(path):

--- a/rest_framework_filters/filters.py
+++ b/rest_framework_filters/filters.py
@@ -49,6 +49,9 @@ class AllLookupsFilter(Filter):
 ###################################################
 # Fixed-up versions of some of the default filters
 ###################################################
+
+# This class is necessary, as directly django-filter's BooleanFilter
+# is using the incorrect form widget.
 class BooleanFilter(BooleanFilter):
     field_class = fields.BooleanField
 

--- a/rest_framework_filters/filters.py
+++ b/rest_framework_filters/filters.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import warnings
 from django.utils import six
 
 from django_filters.filters import *
@@ -60,9 +61,25 @@ class BooleanFilter(BooleanFilter):
 class InSetNumberFilter(Filter):
     field_class = fields.ArrayDecimalField
 
+    def __init__(self, *args, **kwargs):
+        super(InSetNumberFilter, self).__init__(*args, **kwargs)
+        warnings.warn(
+            'InSetNumberFilter is deprecated and no longer necessary. See: '
+            'https://github.com/philipn/django-rest-framework-filters/issues/62',
+            DeprecationWarning, stacklevel=2
+        )
+
 
 class InSetCharFilter(Filter):
     field_class = fields.ArrayCharField
+
+    def __init__(self, *args, **kwargs):
+        super(InSetCharFilter, self).__init__(*args, **kwargs)
+        warnings.warn(
+            'InSetCharFilter is deprecated and no longer necessary. See: '
+            'https://github.com/philipn/django-rest-framework-filters/issues/62',
+            DeprecationWarning, stacklevel=2
+        )
 
 
 class MethodFilter(Filter):

--- a/rest_framework_filters/utils.py
+++ b/rest_framework_filters/utils.py
@@ -1,0 +1,40 @@
+
+from collections import OrderedDict
+
+from django.db.models.constants import LOOKUP_SEP
+from django.db.models.lookups import Transform
+from django.utils import six
+
+
+def lookups_for_field(model_field):
+    """
+    Generates a list of all possible lookup expressions for a model field.
+    """
+    lookups = []
+
+    for expr, lookup in six.iteritems(class_lookups(model_field)):
+        if issubclass(lookup, Transform):
+            lookups += [
+                LOOKUP_SEP.join([expr, transform]) for transform
+                in lookups_for_field(lookup(model_field).output_field)
+            ]
+        else:
+            lookups.append(expr)
+
+    return lookups
+
+
+def class_lookups(model_field):
+    """
+    Get a compiled set of class_lookups for a model field.
+    """
+    field_class = model_field.__class__
+    class_lookups = OrderedDict()
+
+    # traverse MRO in reverse, as this puts standard
+    # lookups before subclass transforms/lookups
+    for cls in field_class.mro()[::-1]:
+        if hasattr(cls, 'class_lookups'):
+            class_lookups.update(getattr(cls, 'class_lookups'))
+
+    return class_lookups

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'djangorestframework',
-        'django-filter>=0.12.0',
+        'django-filter>=0.13.0',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -2,6 +2,8 @@
 import warnings
 from django.test import TestCase
 
+from rest_framework_filters import FilterSet
+
 from .testapp.filters import UserFilter
 
 
@@ -19,3 +21,39 @@ class FilterSetCacheDeprecationTests(TestCase):
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
 
             self.assertIs(UserFilter._subset_cache, cache)
+
+
+class FixFilterFieldDeprecationTests(TestCase):
+
+    def test_override_notifcation(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            class F(FilterSet):
+                @classmethod
+                def fix_filter_field(cls, f):
+                    return super(F, cls).fix_filter_field(f)
+
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+
+    def test_override_notifcation_without_invoking_base(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            class F(FilterSet):
+                @classmethod
+                def fix_filter_field(cls, f):
+                    return f
+
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+
+    def test_no_override_notification(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            class F(FilterSet):
+                pass
+
+            self.assertEqual(len(w), 0)

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -99,3 +99,38 @@ class AllLookupsDeprecationTests(TestCase):
                     fields = ['last_login']
 
             self.assertEqual(len(w), 0)
+
+
+class InLookupDeprecationTests(TestCase):
+
+    def test_char_filter_deprecations(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            class F(FilterSet):
+                username__in = filters.InSetCharFilter(name='username', lookup_expr='in')
+
+                class Meta:
+                    model = User
+
+            self.assertEqual(len(w), 1)
+
+            # Generate another warning for field
+            F({'username__in': 'a'}).qs
+            self.assertEqual(len(w), 2)
+
+    def test_number_filter_deprecations(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            class F(FilterSet):
+                id__in = filters.InSetNumberFilter(name='id', lookup_expr='in')
+
+                class Meta:
+                    model = User
+
+            self.assertEqual(len(w), 1)
+
+            # Generate another warning for field
+            F({'id__in': '1'}).qs
+            self.assertEqual(len(w), 2)

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -3,7 +3,9 @@ import warnings
 from django.test import TestCase
 
 from rest_framework_filters import FilterSet
+from rest_framework_filters import filters
 
+from .testapp.models import User
 from .testapp.filters import UserFilter
 
 
@@ -55,5 +57,45 @@ class FixFilterFieldDeprecationTests(TestCase):
 
             class F(FilterSet):
                 pass
+
+            self.assertEqual(len(w), 0)
+
+
+class AllLookupsDeprecationTests(TestCase):
+
+    def test_ALL_LOOKUPS_notification(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            class F(FilterSet):
+                class Meta:
+                    model = User
+                    fields = {
+                        'last_login': filters.ALL_LOOKUPS,
+                    }
+
+            self.assertEqual(len(w), 1)
+
+    def test_no_notification_for__all__(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            class F(FilterSet):
+                class Meta:
+                    model = User
+                    fields = {
+                        'last_login': '__all__',
+                    }
+
+            self.assertEqual(len(w), 0)
+
+    def test_no_notification_for_fields_list(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            class F(FilterSet):
+                class Meta:
+                    model = User
+                    fields = ['last_login']
 
             self.assertEqual(len(w), 0)

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -1,11 +1,10 @@
-# -*- coding:utf-8 -*-
+
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import datetime
 
-from django.test import TestCase, override_settings
-from django.utils.dateparse import parse_time, parse_datetime
+from django.test import TestCase
 
 from rest_framework_filters import filters
 
@@ -35,17 +34,11 @@ from .testapp.filters import (
     CFilter,
     PersonFilter,
 
-    AllLookupsPersonDateFilter,
+    # AllLookupsPersonDateFilter,
     # ExplicitLookupsPersonDateFilter,
-    InSetLookupPersonIDFilter,
-    InSetLookupPersonNameFilter,
+    # InSetLookupPersonIDFilter,
+    # InSetLookupPersonNameFilter,
 )
-
-
-def add_timedelta(time, timedelta):
-    dt = datetime.datetime.combine(datetime.datetime.today(), time)
-    dt += timedelta
-    return dt.time()
 
 
 class TestFilterSets(TestCase):
@@ -534,182 +527,7 @@ class MethodFilterTests(TestCase):
         self.assertEqual(results[0].comment, "Cover 2")
 
 
-class DatetimeTests(TestCase):
-
-    @classmethod
-    def setUpTestData(cls):
-        john = Person.objects.create(name="John")
-
-        # Created at least one second apart
-        mark = Person.objects.create(name="Mark", best_friend=john)
-        mark.time_joined = add_timedelta(mark.time_joined, datetime.timedelta(seconds=1))
-        mark.datetime_joined += datetime.timedelta(seconds=1)
-        mark.save()
-
-    def test_implicit_date_filters(self):
-        john = Person.objects.get(name="John")
-        # Mark was created at least one second after John.
-        # mark = Person.objects.get(name="Mark")
-
-        from rest_framework import serializers
-        from rest_framework.renderers import JSONRenderer
-
-        class PersonSerializer(serializers.ModelSerializer):
-            class Meta:
-                model = Person
-
-        # Figure out what the date strings should look like based on the
-        # serializer output.
-        data = PersonSerializer(john).data
-
-        date_str = JSONRenderer().render(data['date_joined']).decode('utf-8').strip('"')
-
-        # Adjust for imprecise rendering of time
-        datetime_str = JSONRenderer().render(parse_datetime(data['datetime_joined']) + datetime.timedelta(seconds=0.6)).decode('utf-8').strip('"')
-
-        # Adjust for imprecise rendering of time
-        dt = datetime.datetime.combine(datetime.date.today(), parse_time(data['time_joined'])) + datetime.timedelta(seconds=0.6)
-        time_str = JSONRenderer().render(dt.time()).decode('utf-8').strip('"')
-
-        # DateField
-        GET = {
-            'date_joined__lte': date_str,
-        }
-        f = AllLookupsPersonDateFilter(GET, queryset=Person.objects.all())
-        self.assertEqual(len(list(f)), 2)
-        p = list(f)[0]
-
-        # DateTimeField
-        GET = {
-            'datetime_joined__lte': datetime_str,
-        }
-        f = AllLookupsPersonDateFilter(GET, queryset=Person.objects.all())
-        self.assertEqual(len(list(f)), 1)
-        p = list(f)[0]
-        self.assertEqual(p.name, "John")
-
-        # TimeField
-        GET = {
-            'time_joined__lte': time_str,
-        }
-        f = AllLookupsPersonDateFilter(GET, queryset=Person.objects.all())
-        self.assertEqual(len(list(f)), 1)
-        p = list(f)[0]
-        self.assertEqual(p.name, "John")
-
-    @override_settings(USE_TZ=True)
-    def test_datetime_timezone_awareness(self):
-        # Addresses issue #24 - ensure that datetime strings terminating
-        # in 'Z' are correctly handled.
-        from rest_framework import serializers
-        from rest_framework.renderers import JSONRenderer
-
-        class PersonSerializer(serializers.ModelSerializer):
-            class Meta:
-                model = Person
-
-        # Figure out what the date strings should look like based on the
-        # serializer output.
-        john = Person.objects.get(name="John")
-        data = PersonSerializer(john).data
-        datetime_str = JSONRenderer().render(parse_datetime(data['datetime_joined']) + datetime.timedelta(seconds=0.6)).decode('utf-8').strip('"')
-
-        # This is more for documentation - DRF appends a 'Z' to timezone aware UTC datetimes when rendering:
-        # https://github.com/tomchristie/django-rest-framework/blob/3.2.0/rest_framework/fields.py#L1002-L1006
-        self.assertTrue(datetime_str.endswith('Z'))
-
-        GET = {
-            'datetime_joined__lte': datetime_str,
-        }
-        f = AllLookupsPersonDateFilter(GET, queryset=Person.objects.all())
-        self.assertEqual(len(list(f)), 1)
-        p = list(f)[0]
-        self.assertEqual(p.name, "John")
-
-
 class FilterOverrideTests(TestCase):
-
-    @classmethod
-    def setUpTestData(cls):
-        john = Person.objects.create(name="John")
-        Person.objects.create(name="Mark", best_friend=john)
-
-        User.objects.create(username="user1", email="user1@example.org", is_active=True, last_login=datetime.date.today())
-        User.objects.create(username="user2", email="user2@example.org", is_active=False)
-
-    def test_inset_number_filter(self):
-        p1 = Person.objects.get(name="John").pk
-        p2 = Person.objects.get(name="Mark").pk
-
-        ALL_GET = {
-            'pk__in': '{:d},{:d}'.format(p1, p2),
-        }
-        f = InSetLookupPersonIDFilter(ALL_GET, queryset=Person.objects.all())
-        f = [x.pk for x in f]
-        self.assertEqual(len(f), 2)
-        self.assertIn(p1, f)
-        self.assertIn(p2, f)
-
-        INVALID_GET = {
-            'pk__in': '{:d},c{:d}'.format(p1, p2)
-        }
-        f = InSetLookupPersonIDFilter(INVALID_GET, queryset=Person.objects.all())
-        self.assertEqual(len(list(f)), 0)
-
-        EXTRA_GET = {
-            'pk__in': '{:d},{:d},{:d}'.format(p1, p2, p1*p2)
-        }
-        f = InSetLookupPersonIDFilter(EXTRA_GET, queryset=Person.objects.all())
-        f = [x.pk for x in f]
-        self.assertEqual(len(f), 2)
-        self.assertIn(p1, f)
-        self.assertIn(p2, f)
-
-        DISORDERED_GET = {
-            'pk__in': '{:d},{:d},{:d}'.format(p2, p2*p1, p1)
-        }
-        f = InSetLookupPersonIDFilter(DISORDERED_GET, queryset=Person.objects.all())
-        f = [x.pk for x in f]
-        self.assertEqual(len(f), 2)
-        self.assertIn(p1, f)
-        self.assertIn(p2, f)
-
-    def test_inset_char_filter(self):
-        p1 = Person.objects.get(name="John").name
-        p2 = Person.objects.get(name="Mark").name
-
-        ALL_GET = {
-            'name__in': '{},{}'.format(p1, p2),
-        }
-        f = InSetLookupPersonNameFilter(ALL_GET, queryset=Person.objects.all())
-        f = [x.name for x in f]
-        self.assertEqual(len(f), 2)
-        self.assertIn(p1, f)
-        self.assertIn(p2, f)
-
-        NONEXISTENT_GET = {
-            'name__in': '{},Foo{}'.format(p1, p2)
-        }
-        f = InSetLookupPersonNameFilter(NONEXISTENT_GET, queryset=Person.objects.all())
-        self.assertEqual(len(list(f)), 1)
-
-        EXTRA_GET = {
-            'name__in': '{},{},{}'.format(p1, p2, p1+p2)
-        }
-        f = InSetLookupPersonNameFilter(EXTRA_GET, queryset=Person.objects.all())
-        f = [x.name for x in f]
-        self.assertEqual(len(f), 2)
-        self.assertIn(p1, f)
-        self.assertIn(p2, f)
-
-        DISORDERED_GET = {
-            'name__in': '{},{},{}'.format(p2, p2+p1, p1)
-        }
-        f = InSetLookupPersonNameFilter(DISORDERED_GET, queryset=Person.objects.all())
-        f = [x.name for x in f]
-        self.assertEqual(len(f), 2)
-        self.assertIn(p1, f)
-        self.assertIn(p2, f)
 
     def test_declared_filters(self):
         F = BlogPostOverrideFilter
@@ -734,69 +552,6 @@ class FilterOverrideTests(TestCase):
             F.base_filters['publish_date__isnull'],
             filters.BooleanFilter
         )
-
-    def test_boolean_filter(self):
-        # Capitalized True
-        GET = {'is_active': 'True'}
-        filterset = UserFilter(GET, queryset=User.objects.all())
-        results = list(filterset)
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].username, 'user1')
-
-        # Lowercase True
-        GET = {'is_active': 'true'}
-        filterset = UserFilter(GET, queryset=User.objects.all())
-        results = list(filterset)
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].username, 'user1')
-
-        # Uppercase True
-        GET = {'is_active': 'TRUE'}
-        filterset = UserFilter(GET, queryset=User.objects.all())
-        results = list(filterset)
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].username, 'user1')
-
-        # Capitalized False
-        GET = {'is_active': 'False'}
-        filterset = UserFilter(GET, queryset=User.objects.all())
-        results = list(filterset)
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].username, 'user2')
-
-        # Lowercase False
-        GET = {'is_active': 'false'}
-        filterset = UserFilter(GET, queryset=User.objects.all())
-        results = list(filterset)
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].username, 'user2')
-
-        # Uppercase False
-        GET = {'is_active': 'FALSE'}
-        filterset = UserFilter(GET, queryset=User.objects.all())
-        results = list(filterset)
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].username, 'user2')
-
-    def test_isnull_override(self):
-        import django_filters.filters
-
-        self.assertIsInstance(
-            UserFilter().filters['last_login__isnull'],
-            django_filters.filters.BooleanFilter
-        )
-
-        GET = {'last_login__isnull': 'false'}
-        filterset = UserFilter(GET, queryset=User.objects.all())
-        results = list(filterset)
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].username, 'user1')
-
-        GET = {'last_login__isnull': 'true'}
-        filterset = UserFilter(GET, queryset=User.objects.all())
-        results = list(filterset)
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].username, 'user2')
 
 
 class FilterExclusionTests(TestCase):

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1,0 +1,292 @@
+
+"""
+Regression tests for old `rest_framework_filters.FilterSet` functionality.
+
+Code in this repository is occasionally made obsolete with improvements to the
+underlying django-filter library. This module contains old tests that verify
+that the FilterSet continue to behave as expected.
+"""
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import datetime
+
+from django.test import TestCase, override_settings
+from django.utils.dateparse import parse_time, parse_datetime
+
+from .testapp.models import (
+    User, Person,
+)
+
+from .testapp.filters import (
+    UserFilter,
+    AllLookupsPersonDateFilter,
+    InSetLookupPersonIDFilter,
+    InSetLookupPersonNameFilter,
+)
+
+
+def add_timedelta(time, timedelta):
+    dt = datetime.datetime.combine(datetime.datetime.today(), time)
+    dt += timedelta
+    return dt.time()
+
+
+class IsoDatetimeTests(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        john = Person.objects.create(name="John")
+
+        # Created at least one second apart
+        mark = Person.objects.create(name="Mark", best_friend=john)
+        mark.time_joined = add_timedelta(mark.time_joined, datetime.timedelta(seconds=1))
+        mark.datetime_joined += datetime.timedelta(seconds=1)
+        mark.save()
+
+    def test_implicit_date_filters(self):
+        john = Person.objects.get(name="John")
+        # Mark was created at least one second after John.
+        # mark = Person.objects.get(name="Mark")
+
+        from rest_framework import serializers
+        from rest_framework.renderers import JSONRenderer
+
+        class PersonSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = Person
+                fields = '__all__'
+
+        # Figure out what the date strings should look like based on the
+        # serializer output.
+        data = PersonSerializer(john).data
+
+        date_str = JSONRenderer().render(data['date_joined']).decode('utf-8').strip('"')
+
+        # Adjust for imprecise rendering of time
+        datetime_str = JSONRenderer().render(parse_datetime(data['datetime_joined']) + datetime.timedelta(seconds=0.6)).decode('utf-8').strip('"')
+
+        # Adjust for imprecise rendering of time
+        dt = datetime.datetime.combine(datetime.date.today(), parse_time(data['time_joined'])) + datetime.timedelta(seconds=0.6)
+        time_str = JSONRenderer().render(dt.time()).decode('utf-8').strip('"')
+
+        # DateField
+        GET = {
+            'date_joined__lte': date_str,
+        }
+        f = AllLookupsPersonDateFilter(GET, queryset=Person.objects.all())
+        self.assertEqual(len(list(f)), 2)
+        p = list(f)[0]
+
+        # DateTimeField
+        GET = {
+            'datetime_joined__lte': datetime_str,
+        }
+        f = AllLookupsPersonDateFilter(GET, queryset=Person.objects.all())
+        self.assertEqual(len(list(f)), 1)
+        p = list(f)[0]
+        self.assertEqual(p.name, "John")
+
+        # TimeField
+        GET = {
+            'time_joined__lte': time_str,
+        }
+        f = AllLookupsPersonDateFilter(GET, queryset=Person.objects.all())
+        self.assertEqual(len(list(f)), 1)
+        p = list(f)[0]
+        self.assertEqual(p.name, "John")
+
+    @override_settings(USE_TZ=True)
+    def test_datetime_timezone_awareness(self):
+        # Addresses issue #24 - ensure that datetime strings terminating
+        # in 'Z' are correctly handled.
+        from rest_framework import serializers
+        from rest_framework.renderers import JSONRenderer
+
+        class PersonSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = Person
+                fields = '__all__'
+
+        # Figure out what the date strings should look like based on the
+        # serializer output.
+        john = Person.objects.get(name="John")
+        data = PersonSerializer(john).data
+        datetime_str = JSONRenderer().render(parse_datetime(data['datetime_joined']) + datetime.timedelta(seconds=0.6)).decode('utf-8').strip('"')
+
+        # This is more for documentation - DRF appends a 'Z' to timezone aware UTC datetimes when rendering:
+        # https://github.com/tomchristie/django-rest-framework/blob/3.2.0/rest_framework/fields.py#L1002-L1006
+        self.assertTrue(datetime_str.endswith('Z'))
+
+        GET = {
+            'datetime_joined__lte': datetime_str,
+        }
+        f = AllLookupsPersonDateFilter(GET, queryset=Person.objects.all())
+        self.assertEqual(len(list(f)), 1)
+        p = list(f)[0]
+        self.assertEqual(p.name, "John")
+
+
+class BooleanFilterTests(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        User.objects.create(username="user1", email="user1@example.org", is_active=True, last_login=datetime.date.today())
+        User.objects.create(username="user2", email="user2@example.org", is_active=False)
+
+    def test_boolean_filter(self):
+        # Capitalized True
+        GET = {'is_active': 'True'}
+        filterset = UserFilter(GET, queryset=User.objects.all())
+        results = list(filterset)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].username, 'user1')
+
+        # Lowercase True
+        GET = {'is_active': 'true'}
+        filterset = UserFilter(GET, queryset=User.objects.all())
+        results = list(filterset)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].username, 'user1')
+
+        # Uppercase True
+        GET = {'is_active': 'TRUE'}
+        filterset = UserFilter(GET, queryset=User.objects.all())
+        results = list(filterset)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].username, 'user1')
+
+        # Capitalized False
+        GET = {'is_active': 'False'}
+        filterset = UserFilter(GET, queryset=User.objects.all())
+        results = list(filterset)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].username, 'user2')
+
+        # Lowercase False
+        GET = {'is_active': 'false'}
+        filterset = UserFilter(GET, queryset=User.objects.all())
+        results = list(filterset)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].username, 'user2')
+
+        # Uppercase False
+        GET = {'is_active': 'FALSE'}
+        filterset = UserFilter(GET, queryset=User.objects.all())
+        results = list(filterset)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].username, 'user2')
+
+
+class InLookupTests(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        john = Person.objects.create(name="John")
+        Person.objects.create(name="Mark", best_friend=john)
+
+        User.objects.create(username="user1", email="user1@example.org", is_active=True, last_login=datetime.date.today())
+        User.objects.create(username="user2", email="user2@example.org", is_active=False)
+
+    def test_inset_number_filter(self):
+        p1 = Person.objects.get(name="John").pk
+        p2 = Person.objects.get(name="Mark").pk
+
+        ALL_GET = {
+            'pk__in': '{:d},{:d}'.format(p1, p2),
+        }
+        f = InSetLookupPersonIDFilter(ALL_GET, queryset=Person.objects.all())
+        f = [x.pk for x in f]
+        self.assertEqual(len(f), 2)
+        self.assertIn(p1, f)
+        self.assertIn(p2, f)
+
+        INVALID_GET = {
+            'pk__in': '{:d},c{:d}'.format(p1, p2)
+        }
+        f = InSetLookupPersonIDFilter(INVALID_GET, queryset=Person.objects.all())
+        self.assertEqual(len(list(f)), 0)
+
+        EXTRA_GET = {
+            'pk__in': '{:d},{:d},{:d}'.format(p1, p2, p1*p2)
+        }
+        f = InSetLookupPersonIDFilter(EXTRA_GET, queryset=Person.objects.all())
+        f = [x.pk for x in f]
+        self.assertEqual(len(f), 2)
+        self.assertIn(p1, f)
+        self.assertIn(p2, f)
+
+        DISORDERED_GET = {
+            'pk__in': '{:d},{:d},{:d}'.format(p2, p2*p1, p1)
+        }
+        f = InSetLookupPersonIDFilter(DISORDERED_GET, queryset=Person.objects.all())
+        f = [x.pk for x in f]
+        self.assertEqual(len(f), 2)
+        self.assertIn(p1, f)
+        self.assertIn(p2, f)
+
+    def test_inset_char_filter(self):
+        p1 = Person.objects.get(name="John").name
+        p2 = Person.objects.get(name="Mark").name
+
+        ALL_GET = {
+            'name__in': '{},{}'.format(p1, p2),
+        }
+        f = InSetLookupPersonNameFilter(ALL_GET, queryset=Person.objects.all())
+        f = [x.name for x in f]
+        self.assertEqual(len(f), 2)
+        self.assertIn(p1, f)
+        self.assertIn(p2, f)
+
+        NONEXISTENT_GET = {
+            'name__in': '{},Foo{}'.format(p1, p2)
+        }
+        f = InSetLookupPersonNameFilter(NONEXISTENT_GET, queryset=Person.objects.all())
+        self.assertEqual(len(list(f)), 1)
+
+        EXTRA_GET = {
+            'name__in': '{},{},{}'.format(p1, p2, p1+p2)
+        }
+        f = InSetLookupPersonNameFilter(EXTRA_GET, queryset=Person.objects.all())
+        f = [x.name for x in f]
+        self.assertEqual(len(f), 2)
+        self.assertIn(p1, f)
+        self.assertIn(p2, f)
+
+        DISORDERED_GET = {
+            'name__in': '{},{},{}'.format(p2, p2+p1, p1)
+        }
+        f = InSetLookupPersonNameFilter(DISORDERED_GET, queryset=Person.objects.all())
+        f = [x.name for x in f]
+        self.assertEqual(len(f), 2)
+        self.assertIn(p1, f)
+        self.assertIn(p2, f)
+
+
+class IsNullLookupTests(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        User.objects.create(username="user1", email="user1@example.org", is_active=True, last_login=datetime.date.today())
+        User.objects.create(username="user2", email="user2@example.org", is_active=False)
+
+    def test_isnull_override(self):
+        import django_filters.filters
+
+        self.assertIsInstance(
+            UserFilter().filters['last_login__isnull'],
+            django_filters.filters.BooleanFilter
+        )
+
+        GET = {'last_login__isnull': 'false'}
+        filterset = UserFilter(GET, queryset=User.objects.all())
+        results = list(filterset)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].username, 'user1')
+
+        GET = {'last_login__isnull': 'true'}
+        filterset = UserFilter(GET, queryset=User.objects.all())
+        results = list(filterset)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].username, 'user2')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,52 @@
+
+import unittest
+import django
+from django.test import TestCase
+
+from rest_framework_filters import utils
+
+from .testapp.models import Person
+
+
+class LookupsForFieldTests(TestCase):
+    def test_standard_field(self):
+        model_field = Person._meta.get_field('name')
+        lookups = utils.lookups_for_field(model_field)
+
+        self.assertIn('exact', lookups)
+        if django.VERSION >= (1, 9):
+            self.assertNotIn('year', lookups)
+            self.assertNotIn('date', lookups)
+        else:
+            self.assertIn('year', lookups)
+
+    @unittest.skipIf(django.VERSION < (1, 9), "version does not support transformed lookup expressions")
+    def test_transformed_field(self):
+        model_field = Person._meta.get_field('datetime_joined')
+        lookups = utils.lookups_for_field(model_field)
+
+        self.assertIn('exact', lookups)
+        self.assertIn('year__exact', lookups)
+        self.assertIn('date__year__exact', lookups)
+
+
+class ClassLookupsTests(TestCase):
+    def test_standard_field(self):
+        model_field = Person._meta.get_field('name')
+        class_lookups = utils.class_lookups(model_field)
+
+        self.assertIn('exact', class_lookups)
+        if django.VERSION >= (1, 9):
+            self.assertNotIn('year', class_lookups)
+            self.assertNotIn('date', class_lookups)
+        else:
+            self.assertIn('year', class_lookups)
+
+    @unittest.skipIf(django.VERSION < (1, 9), "version does not support transformed lookup expressions")
+    def test_transformed_field(self):
+        model_field = Person._meta.get_field('datetime_joined')
+        class_lookups = utils.class_lookups(model_field)
+
+        self.assertIn('exact', class_lookups)
+        self.assertIn('year', class_lookups)
+        self.assertIn('date', class_lookups)

--- a/tests/testapp/filters.py
+++ b/tests/testapp/filters.py
@@ -223,4 +223,4 @@ class BlogPostOverrideFilter(FilterSet):
 
     class Meta:
         model = BlogPost
-        fields = {'publish_date': filters.ALL_LOOKUPS, }
+        fields = {'publish_date': '__all__', }

--- a/tests/testapp/filters.py
+++ b/tests/testapp/filters.py
@@ -218,7 +218,7 @@ class InSetLookupPersonNameFilter(FilterSet):
 
 
 class BlogPostOverrideFilter(FilterSet):
-    declared_publish_date__isnull = filters.NumberFilter(name='publish_date', lookup_type='isnull')
+    declared_publish_date__isnull = filters.NumberFilter(name='publish_date', lookup_expr='isnull')
     all_declared_publish_date = filters.AllLookupsFilter(name='publish_date')
 
     class Meta:

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -6,44 +6,44 @@ from django.contrib.auth.models import User
 class Note(models.Model):
     title = models.CharField(max_length=100)
     content = models.TextField()
-    author = models.ForeignKey(User)
+    author = models.ForeignKey(User, on_delete=models.CASCADE)
 
 
 class Post(models.Model):
-    note = models.ForeignKey(Note)
+    note = models.ForeignKey(Note, on_delete=models.CASCADE)
     content = models.TextField()
     date_published = models.DateField(null=True)
 
 
 class Cover(models.Model):
     comment = models.CharField(max_length=100)
-    post = models.ForeignKey(Post)
+    post = models.ForeignKey(Post, on_delete=models.CASCADE)
 
 
 class Page(models.Model):
     title = models.CharField(max_length=100)
     content = models.TextField()
-    previous_page = models.ForeignKey('self', null=True)
+    previous_page = models.ForeignKey('self', null=True, on_delete=models.CASCADE)
 
 
 class A(models.Model):
     title = models.CharField(max_length=100)
-    b = models.ForeignKey('B', null=True)
+    b = models.ForeignKey('B', null=True, on_delete=models.CASCADE)
 
 
 class C(models.Model):
     title = models.CharField(max_length=100)
-    a = models.ForeignKey(A, null=True)
+    a = models.ForeignKey(A, null=True, on_delete=models.CASCADE)
 
 
 class B(models.Model):
     name = models.CharField(max_length=100)
-    c = models.ForeignKey(C, null=True)
+    c = models.ForeignKey(C, null=True, on_delete=models.CASCADE)
 
 
 class Person(models.Model):
     name = models.CharField(max_length=100)
-    best_friend = models.ForeignKey('self', null=True)
+    best_friend = models.ForeignKey('self', null=True, on_delete=models.CASCADE)
 
     date_joined = models.DateField(auto_now_add=True)
     time_joined = models.TimeField(auto_now_add=True)


### PR DESCRIPTION
This is the PR for and closes #62, bringing drf-filters up to speed with the latest work on lookup expression handling. In total, 

- Deprecates `ArrayDecimalField`/`InSetNumberFilter`
- Deprecates `ArrayCharField`/`InSetCharFilter`
- Deprecates `FilterSet.fix_filter_field`
- Deprecates `ALL_LOOKUPS` in favor of `'__all__'` constant.
- Changes `AllLookupsFilter` behavior to generate only valid lookup expressions. Previously, this filter just generated a filter for each sql term in `QUERY_TERMS`. This used to work, but the lookup expression handling in Django has changed, resulting in two things:
  - certain lookups are no longer valid (`date` lookups on an `IntegerField`)
  - you can chain/transform lookups (`date__year__gte`)

Deprecating `ALL_LOOKUPS` in favor of `'__all__'` has two positive effects. 
- it no longer has to be imported.
- reduced code paths and improved consistency. `ALL_LOOKUPS` was just an alias for `QUERY_TERMS` and was not handled in the same manner as the declared `AllLookupsFilter`s. `'__all__'` is now a shorthand that is converted into an `AllLookupsFilter`, ensuring that both have identical execution.

Note:
This won't succeed until the lookup expression handling in django-filter has been released.