### PR TITLE
Simplify RelatedFilter

### DIFF
--- a/rest_framework_filters/filters.py
+++ b/rest_framework_filters/filters.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from collections import OrderedDict
 from django.utils import six
 
 from django_filters.filters import *
@@ -35,27 +34,6 @@ class RelatedFilter(ModelChoiceFilter):
 
         return locals()
     filterset = property(**filterset())
-
-    def get_filterset_subset(self, filter_names):
-        """
-        Returns a FilterSet subclass that contains the subset of filters
-        specified in `filter_names`. This is useful for creating FilterSets
-        used across relationships, as it minimizes the deepcopy overhead
-        incurred when instantiating the FilterSet.
-        """
-        BaseFilterSet = self.filterset
-
-        class FilterSetSubset(BaseFilterSet):
-            pass
-
-        FilterSetSubset.__name__ = str('%sSubset' % (BaseFilterSet.__name__))
-        FilterSetSubset.base_filters = OrderedDict([
-            (name, f)
-            for name, f in six.iteritems(BaseFilterSet.base_filters)
-            if name in filter_names
-        ])
-
-        return FilterSetSubset
 
     @property
     def field(self):

--- a/rest_framework_filters/filters.py
+++ b/rest_framework_filters/filters.py
@@ -22,7 +22,6 @@ def _import_class(path):
 class RelatedFilter(ModelChoiceFilter):
     def __init__(self, filterset, *args, **kwargs):
         self.filterset = filterset
-        # self.parent_relation = kwargs.get('parent_relation', None)
         return super(RelatedFilter, self).__init__(*args, **kwargs)
 
     def filterset():
@@ -58,8 +57,11 @@ class RelatedFilter(ModelChoiceFilter):
 
         return FilterSetSubset
 
-    def setup_filterset(self):
-        self.extra['queryset'] = self.filterset._meta.model.objects.all()
+    @property
+    def field(self):
+        # if no queryset is provided, default to the filterset's default queryset
+        self.extra.setdefault('queryset', self.filterset._meta.model._default_manager.all())
+        return super(RelatedFilter, self).field
 
 
 class AllLookupsFilter(Filter):

--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -129,7 +129,7 @@ class FilterSet(six.with_metaclass(FilterSetMetaclass, filterset.FilterSet)):
 
             # otherwise build and insert it into the cache
             if subset_class is None:
-                subset_class = related_filter.get_filterset_subset(filter_names)
+                subset_class = related_filter.filterset.get_subset(filter_names)
                 self.cache_set(key, subset_class)
 
             # initialize and copy filters
@@ -161,6 +161,26 @@ class FilterSet(six.with_metaclass(FilterSetMetaclass, filterset.FilterSet)):
         f = cls.base_filters.get(related_param, None)
         if isinstance(f, filters.RelatedFilter):
             return related_param
+
+    @classmethod
+    def get_subset(cls, filter_names):
+        """
+        Returns a FilterSet subclass that contains the subset of filters
+        specified in `filter_names`. This is useful for creating FilterSets
+        used across relationships, as it minimizes the deepcopy overhead
+        incurred when instantiating the FilterSet.
+        """
+        class FilterSetSubset(cls):
+            pass
+
+        FilterSetSubset.__name__ = str('%sSubset' % (cls.__name__))
+        FilterSetSubset.base_filters = OrderedDict([
+            (name, f)
+            for name, f in six.iteritems(cls.base_filters)
+            if name in filter_names
+        ])
+
+        return FilterSetSubset
 
     def cache_key(self, filterset, filter_names):
         return '%sSubset-%s' % (filterset.__name__, '-'.join(sorted(filter_names)), )

--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -66,8 +66,6 @@ class FilterSet(six.with_metaclass(FilterSetMetaclass, filterset.FilterSet)):
 
         for name, filter_ in six.iteritems(self.filters.copy()):
             if isinstance(filter_, filters.RelatedFilter):
-                filter_.setup_filterset()
-
                 # Add an 'isnull' filter to allow checking if the relation is empty.
                 filter_name = "%s%sisnull" % (filter_.name, LOOKUP_SEP)
                 if filter_name not in self.filters:

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -304,9 +304,9 @@ class TestFilterSets(TestCase):
         titles = set([p.title for p in f])
         self.assertEqual(titles, set(["First post", "Second post"]))
 
-    def test_get_filterset_subset(self):
+    def test_get_subset(self):
         related_filter = NoteFilterWithRelated.base_filters['author']
-        filterset_class = related_filter.get_filterset_subset(['email'])
+        filterset_class = related_filter.filterset.get_subset(['email'])
 
         # ensure that the class name is useful when debugging
         self.assertEqual(filterset_class.__name__, 'UserFilterSubset')


### PR DESCRIPTION
Simplifies `RelatedFilter`.
- removes the need for the `FilterSet` to call `setup_filterset()`.
- refactors `RelatedFilter.get_filter_subset()` as `FilterSet.get_subset()`, as this is more the responsibility of the FilterSet.

Decided against adding deprecating warnings for get_filter_subset, as this is an internal method and unlikely to be overridden. 