### PR TITLE
Fixed Filterset ordering when order_by is True

### DIFF
--- a/tests/testapp/filters.py
+++ b/tests/testapp/filters.py
@@ -133,6 +133,12 @@ class BlogPostFilter(FilterSet):
         model = BlogPost
 
 
+class OrderedBlogPostFilter(BlogPostFilter):
+    default_order = ['-id']
+    class Meta(BlogPostFilter.Meta):
+        order_by = True
+
+
 class UserFilterWithDifferentName(FilterSet):
     name = filters.CharFilter(name='username')
 


### PR DESCRIPTION
Since the fiters are lazily evaluated (cf. https://github.com/philipn/django-rest-framework-filters/commit/55e701f20c1873a93ff1c840ca03e5065053fa1f) using a Filterset with order_by is broken.

When order_by is True Filterset.get_ordering_field may return a
ChoiceField with no choices because self.filters is changed
while accessing self.qs and self.filters is used to create the list of choices.
The field doesn't validate, the form has error and we end up with an empty
filterset.

This implementation fixes it by building and ordering field not based on
Filterset.filters but on the tracked model fields list.

It also allows complex ordering like `o=field1,-field2,field3`, who
would not have been validated by the original ChoiceField, by using a
simple CharField, a Select widget and a validator actually checking if
the order value is valid.

The Filterset can have a default_order attribute to replace the first
choice of the ordering field that is used by django-filter by default.

Some of this code may actually be better directly in django-filters like the proper validation of the order value but as the bug showed up here, so is my PR.