### PR TITLE
Temporarily fix some issues with all lookups

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,11 +1,18 @@
-Unreleased
-----------
+Unreleased:
+-----------
 
-* Fixes #79, enabling compatibility with ``django.contrib.postgres``
-* Adds basic infinite recursion prevention for chainable transforms
+v0.8.1:
+-------
 
-v0.8.0
-------
+* Fix bug where AllLookupsFilter would override a declared filter of the same name
+* #84 Fix AllLookupsFilter compatibility with ``ForeignObject`` related fields
+* #82 Fix AllLookupsFilter compatibility with mixin FilterSets
+* #81 Fix bug where FilterSet modified ``ViewSet.filter_fields``
+* #79 Prevent infinite recursion for chainable transforms, fixing compatiblity
+  w/ ``django.contrib.postgres``
+
+v0.8.0:
+-------
 
 This release is tied to a major update of django-filter (more details in #66),
 which fixes how lookup expressions are resolved. 'in', 'range', and 'isnull'
@@ -15,8 +22,8 @@ This has the following effects:
   * Deprecates ArrayDecimalField/InSetNumberFilter
   * Deprecates ArrayCharField/InSetCharFilter
   * Deprecates FilterSet.fix_filter_field
-  * Deprecates ALL_LOOKUPS in favor of '__all__' constant.
-  * AllLookupsFilter now generates only valid lookup expressions.
+  * Deprecates ALL_LOOKUPS in favor of '__all__' constant
+  * AllLookupsFilter now generates only valid lookup expressions
 
 * #2 'range' lookup types do not work
 * #15 Date lookup types do not work (year, day, ...)
@@ -52,7 +59,7 @@ v0.5.0:
 * #31 Fix timezone-aware datetime handling
 * #36 Fix '__in' filter to work with strings
 * #33 Fix RelatedFilter handling to not override existing isnull filters
-* #35 Fix python 3.5 compatibility issue.
+* #35 Fix python 3.5 compatibility issue
 * Drops support for Django 1.6 and below
 
 v0.4.0:

--- a/rest_framework_filters/utils.py
+++ b/rest_framework_filters/utils.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 import django
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.expressions import Expression
+from django.db.models.fields.related import ForeignObject
 from django.db.models.lookups import Transform
 from django.utils import six
 
@@ -12,6 +13,11 @@ def lookups_for_field(model_field):
     """
     Generates a list of all possible lookup expressions for a model field.
     """
+    # This is a hack to work around:
+    # https://github.com/django/django/pull/6906
+    if isinstance(model_field, ForeignObject):
+        return ['exact', 'gt', 'gte', 'lt', 'lte', 'in', 'isnull']
+
     lookups = []
 
     for expr, lookup in six.iteritems(class_lookups(model_field)):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 
 from rest_framework_filters import utils
 
-from .testapp.models import Person
+from .testapp.models import Person, Note
 
 
 class LookupsForFieldTests(TestCase):
@@ -28,6 +28,15 @@ class LookupsForFieldTests(TestCase):
         self.assertIn('exact', lookups)
         self.assertIn('year__exact', lookups)
         self.assertIn('date__year__exact', lookups)
+
+    def test_relation_field(self):
+        # ForeignObject relations are special cased currently
+        model_field = Note._meta.get_field('author')
+        lookups = utils.lookups_for_field(model_field)
+
+        self.assertIn('exact', lookups)
+        self.assertIn('in', lookups)
+        self.assertNotIn('regex', lookups)
 
 
 @unittest.skipIf(django.VERSION < (1, 9), "version does not support transformed lookup expressions")


### PR DESCRIPTION
- hardcodes the list of lookups for related filters until django/django#6906 is resolved.
- temp fix to `__all__` handling in which existing, declared filters were overwritten by an AllLookupsFilter.