### PR TITLE
Update Django and Python versions in testing matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: false
 
 python:
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"
@@ -21,8 +20,6 @@ script:
 
 matrix:
   exclude:
-    - python: "3.2"
-      env: DJANGO="django>=1.9.0,<1.10.0" REST_FRAMEWORK="djangorestframework>=3.3,<3.4"
     - python: "3.3"
       env: DJANGO="django>=1.9.0,<1.10.0" REST_FRAMEWORK="djangorestframework>=3.3,<3.4"
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   - "3.4"
   - "3.5"
 env:
+  - DJANGO="django>=1.10.0,<1.11.0" REST_FRAMEWORK="djangorestframework>=3.4,<3.5"
   - DJANGO="django>=1.9.0,<1.10.0" REST_FRAMEWORK="djangorestframework>=3.4,<3.5"
   - DJANGO="django>=1.8.0,<1.9.0" REST_FRAMEWORK="djangorestframework>=3.4,<3.5"
   - DJANGO="django>=1.8.0,<1.9.0" REST_FRAMEWORK="djangorestframework>=3.3,<3.4"
@@ -20,6 +21,8 @@ script:
 
 matrix:
   exclude:
+    - python: "3.3"
+      env: DJANGO="django>=1.10.0,<1.11.0" REST_FRAMEWORK="djangorestframework>=3.4,<3.5"
     - python: "3.3"
       env: DJANGO="django>=1.9.0,<1.10.0" REST_FRAMEWORK="djangorestframework>=3.4,<3.5"
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ python:
   - "3.4"
   - "3.5"
 env:
-  - DJANGO="django>=1.9.0,<1.10.0" REST_FRAMEWORK="djangorestframework>=3.3,<3.4"
+  - DJANGO="django>=1.9.0,<1.10.0" REST_FRAMEWORK="djangorestframework>=3.4,<3.5"
+  - DJANGO="django>=1.8.0,<1.9.0" REST_FRAMEWORK="djangorestframework>=3.4,<3.5"
   - DJANGO="django>=1.8.0,<1.9.0" REST_FRAMEWORK="djangorestframework>=3.3,<3.4"
 install:
   - travis_retry pip install -q $DJANGO $REST_FRAMEWORK "coverage==3.7.1"
@@ -20,5 +21,5 @@ script:
 matrix:
   exclude:
     - python: "3.3"
-      env: DJANGO="django>=1.9.0,<1.10.0" REST_FRAMEWORK="djangorestframework>=3.3,<3.4"
+      env: DJANGO="django>=1.9.0,<1.10.0" REST_FRAMEWORK="djangorestframework>=3.4,<3.5"
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ python:
 env:
   - DJANGO="django>=1.9.0,<1.10.0" REST_FRAMEWORK="djangorestframework>=3.3,<3.4"
   - DJANGO="django>=1.8.0,<1.9.0" REST_FRAMEWORK="djangorestframework>=3.3,<3.4"
-  - DJANGO="django>=1.8.0,<1.9.0" REST_FRAMEWORK="djangorestframework>=3.2,<3.3"
 install:
   - travis_retry pip install -q $DJANGO $REST_FRAMEWORK "coverage==3.7.1"
   - pip install .

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Requirements
 ------------
 
 * Python 2.7 or 3.3+
-* Django 1.8+
+* Django 1.8, 1.9, 1.10
 * Django REST framework 3.3, 3.4
 
 Usage

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Requirements
 
 * Python 2.7 or 3.3+
 * Django 1.8+
-* Django REST framework 3.3
+* Django REST framework 3.3, 3.4
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Installation
 Requirements
 ------------
 
-* Python 2.7+
+* Python 2.7 or 3.3+
 * Django 1.8+
 * Django REST framework 3.0+
 

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Requirements
 
 * Python 2.7 or 3.3+
 * Django 1.8+
-* Django REST framework 3.0+
+* Django REST framework 3.3
 
 Usage
 -----


### PR DESCRIPTION
* Stop testing on Python 3.2 (since it's [no longer supported](https://docs.python.org/devguide/#status-of-python-branches) as of 2016-02-20)
* Stop testing on django-rest-framework 3.2 (see commit message for more details)
* Test with django-rest-framework 3.4
* Test on Django 1.10