### PR TITLE
Deprecate AllLookupsFilter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,6 @@ next release.
 
 * Updates django-filter requirement to 0.15.0
 * #101 Add support for Django 1.10, set DRF support to 3.3, 3.4, and drop support for python 3.2
-* #114 Add ``lookups`` argument to ``RelatedFilter``
 * #113 Deprecated ``MethodFilter`` for new ``Filter.method`` argument
 
 v0.8.1:

--- a/rest_framework_filters/filters.py
+++ b/rest_framework_filters/filters.py
@@ -21,9 +21,8 @@ def _import_class(path):
 
 
 class RelatedFilter(ModelChoiceFilter):
-    def __init__(self, filterset, lookups=None, *args, **kwargs):
+    def __init__(self, filterset, *args, **kwargs):
         self.filterset = filterset
-        self.lookups = lookups
         return super(RelatedFilter, self).__init__(*args, **kwargs)
 
     def filterset():
@@ -46,7 +45,7 @@ class RelatedFilter(ModelChoiceFilter):
 
 
 class AllLookupsFilter(Filter):
-    lookups = '__all__'
+    pass
 
 
 ###################################################

--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -54,18 +54,10 @@ class FilterSetMetaclass(filterset.FilterSetMetaclass):
         # Populate our FilterSet fields with all the possible
         # filters for the AllLookupsFilter field.
         for name, filter_ in six.iteritems(new_class.base_filters.copy()):
-            if isinstance(filter_, (filters.AllLookupsFilter, filters.RelatedFilter)):
+            if isinstance(filter_, filters.AllLookupsFilter):
                 field = filterset.get_model_field(opts.model, filter_.name)
 
-                lookups = filter_.lookups or []
-                if lookups == '__all__':
-                    lookups = utils.lookups_for_field(field)
-
-                for lookup_expr in lookups:
-                    if isinstance(filter_, filters.RelatedFilter) and lookup_expr == 'exact':
-                        # Don't replace the RelatedFilter
-                        continue
-
+                for lookup_expr in utils.lookups_for_field(field):
                     if isinstance(field, ForeignObjectRel):
                         f = new_class.filter_for_reverse_field(field, filter_.name)
                     else:

--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -55,6 +55,12 @@ class FilterSetMetaclass(filterset.FilterSetMetaclass):
         # filters for the AllLookupsFilter field.
         for name, filter_ in six.iteritems(new_class.base_filters.copy()):
             if isinstance(filter_, filters.AllLookupsFilter):
+                warnings.warn(
+                    "'AllLookupsFilter' is no longer supported. Use the 'Meta.fields' option instead. See: "
+                    "https://github.com/philipn/django-rest-framework-filters/issues/122",
+                    DeprecationWarning, stacklevel=2
+                )
+
                 field = filterset.get_model_field(opts.model, filter_.name)
 
                 for lookup_expr in utils.lookups_for_field(field):

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -170,3 +170,33 @@ class MethodFilterDeprecationTests(TestCase):
                     fields = []
 
             self.assertEqual(len(w), 1)
+
+
+class AllLookupsFilterDeprecationTests(TestCase):
+
+    def test_notification(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            class F(FilterSet):
+                username = filters.AllLookupsFilter()
+
+                class Meta:
+                    model = User
+                    fields = []
+
+            self.assertEqual(len(w), 1)
+            self.assertIn("'AllLookupsFilter' is no longer supported.", str(w[0].message))
+
+    def test_no_notification(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            class F(FilterSet):
+                class Meta:
+                    model = User
+                    fields = {
+                        'username': '__all__',
+                    }
+
+            self.assertEqual(len(w), 0)

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -66,29 +66,6 @@ class LookupsFilterTests(TestCase):
         self.assertIsInstance(F.base_filters['author'], filters.RelatedFilter)
         self.assertIsInstance(F.base_filters['author__in'], BaseInFilter)
 
-    def test_relatedfilter_lookups(self):
-        # ensure that related filter is compatible with __all__ lookups.
-        class F(FilterSet):
-            author = filters.RelatedFilter(UserFilter, lookups='__all__')
-
-            class Meta:
-                model = Note
-
-        self.assertIsInstance(F.base_filters['author'], filters.RelatedFilter)
-        self.assertIsInstance(F.base_filters['author__in'], BaseInFilter)
-
-    def test_relatedfilter_lookups_list(self):
-        # ensure that related filter is compatible with __all__ lookups.
-        class F(FilterSet):
-            author = filters.RelatedFilter(UserFilter, lookups=['in'])
-
-            class Meta:
-                model = Note
-
-        self.assertEqual(len([f for f in F.base_filters if f.startswith('author')]), 2)
-        self.assertIsInstance(F.base_filters['author'], filters.RelatedFilter)
-        self.assertIsInstance(F.base_filters['author__in'], BaseInFilter)
-
     def test_declared_filter_persistence_with__all__(self):
         # ensure that __all__ does not overwrite declared filters.
         class F(FilterSet):


### PR DESCRIPTION
Resolves #121.

Instead of:
```py
class UserFilter(FilterSet):
    username = filters.AllLookupsFilter()

    class Meta:
        model = User
```

do the following:
```py
class UserFilter(FilterSet):
    class Meta:
        model = User
        fields = {
            'username': '__all__',
        }
```
