### PR TITLE
Declared filters overwritten by AllLookupsFilter

### DIFF
--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -28,6 +28,18 @@ class LookupsFilterTests(TestCase):
     Test basic filter construction for `AllLookupsFilter`, '__all__', and `RelatedFilter.lookups`.
     """
 
+    def test_alllookupsfilter_meta_fields_unmodified(self):
+        f = []
+
+        class F(FilterSet):
+            id = filters.AllLookupsFilter()
+
+            class Meta:
+                model = Note
+                fields = f
+
+        self.assertIs(F._meta.fields, f)
+
     def test_alllookupsfilter_replaced(self):
         # See: https://github.com/philipn/django-rest-framework-filters/issues/118
         class F(FilterSet):

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -25,8 +25,7 @@ from .testapp.filters import (
 
 class LookupsFilterTests(TestCase):
     """
-    Test basic filter construction for `AllLookupsFilter`, '__all__',
-    and `RelatedFilter.lookups`.
+    Test basic filter construction for `AllLookupsFilter`, '__all__', and `RelatedFilter.lookups`.
     """
 
     def test_alllookupsfilter_replaced(self):
@@ -91,16 +90,29 @@ class LookupsFilterTests(TestCase):
 
     def test_declared_filter_persistence_with__all__(self):
         # ensure that __all__ does not overwrite declared filters.
+        f = filters.Filter()
+
         class F(FilterSet):
-            name = filters.ChoiceFilter(lookup_expr='iexact')
+            name = f
 
             class Meta:
                 model = Person
-                fields = {
-                    'name': '__all__',
-                }
+                fields = {'name': '__all__'}
 
-        self.assertIsInstance(F.base_filters['name'], filters.ChoiceFilter)
+        self.assertIs(F.base_filters['name'], f)
+
+    def test_declared_filter_persistence_with_alllookupsfilter(self):
+        # ensure that AllLookupsFilter does not overwrite declared filters.
+        f = filters.Filter()
+
+        class F(FilterSet):
+            id = filters.AllLookupsFilter()
+            id__in = f
+
+            class Meta:
+                model = Note
+
+        self.assertIs(F.base_filters['id__in'], f)
 
 
 class GetFilterNameTests(TestCase):


### PR DESCRIPTION
Declared filters are overwritten by the current implementation of `AllLookupsFilter`. This does not affect `Meta.fields` w/ `'__all__'`

This also uses `filters_for_model` to generate the filters for `AllLookupsFilter` and `RelatedFilter.lookups`. This removes the code duplication mentioned in #121.