### PR TITLE
Update django-filter to 1.0

### DIFF
--- a/rest_framework_filters/filters.py
+++ b/rest_framework_filters/filters.py
@@ -4,16 +4,10 @@ from __future__ import unicode_literals
 from django.utils import six
 
 from django_filters.rest_framework.filters import *
+from rest_framework_filters.utils import import_class
 
 
 ALL_LOOKUPS = '__all__'
-
-
-def _import_class(path):
-    module_path, class_name = path.rsplit('.', 1)
-    class_name = str(class_name)  # Ensure not unicode on py2.x
-    module = __import__(module_path, fromlist=[class_name], level=0)
-    return getattr(module, class_name)
 
 
 class AutoFilter(Filter):
@@ -33,7 +27,7 @@ class RelatedFilter(AutoFilter, ModelChoiceFilter):
     def filterset():
         def fget(self):
             if isinstance(self._filterset, six.string_types):
-                self._filterset = _import_class(self._filterset)
+                self._filterset = import_class(self._filterset)
             return self._filterset
 
         def fset(self, value):

--- a/rest_framework_filters/filters.py
+++ b/rest_framework_filters/filters.py
@@ -36,11 +36,11 @@ class RelatedFilter(AutoFilter, ModelChoiceFilter):
         return locals()
     filterset = property(**filterset())
 
-    @property
-    def field(self):
-        # if no queryset is provided, default to the filterset's default queryset
-        self.extra.setdefault('queryset', self.filterset._meta.model._default_manager.all())
-        return super(RelatedFilter, self).field
+    def get_queryset(self, request):
+        queryset = super(RelatedFilter, self).get_queryset(request)
+        if queryset is not None:
+            return queryset
+        return self.filterset._meta.model._default_manager.all()
 
 
 class AllLookupsFilter(AutoFilter):

--- a/rest_framework_filters/filters.py
+++ b/rest_framework_filters/filters.py
@@ -16,11 +16,19 @@ def _import_class(path):
     return getattr(module, class_name)
 
 
-class RelatedFilter(ModelChoiceFilter):
-    def __init__(self, filterset, lookups=None, *args, **kwargs):
+class AutoFilter(Filter):
+    def __init__(self, *args, **kwargs):
+        self.lookups = kwargs.pop('lookups', [])
+
+        super(AutoFilter, self).__init__(*args, **kwargs)
+
+
+class RelatedFilter(AutoFilter, ModelChoiceFilter):
+    def __init__(self, filterset, *args, **kwargs):
         self.filterset = filterset
-        self.lookups = lookups
-        return super(RelatedFilter, self).__init__(*args, **kwargs)
+        kwargs.setdefault('lookups', None)
+
+        super(RelatedFilter, self).__init__(*args, **kwargs)
 
     def filterset():
         def fget(self):
@@ -41,5 +49,8 @@ class RelatedFilter(ModelChoiceFilter):
         return super(RelatedFilter, self).field
 
 
-class AllLookupsFilter(Filter):
-    lookups = ALL_LOOKUPS
+class AllLookupsFilter(AutoFilter):
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('lookups', ALL_LOOKUPS)
+
+        super(AllLookupsFilter, self).__init__(*args, **kwargs)

--- a/rest_framework_filters/utils.py
+++ b/rest_framework_filters/utils.py
@@ -9,6 +9,13 @@ from django.db.models.lookups import Transform
 from django.utils import six
 
 
+def import_class(path):
+    module_path, class_name = path.rsplit('.', 1)
+    class_name = str(class_name)  # Ensure not unicode on py2.x
+    module = __import__(module_path, fromlist=[class_name], level=0)
+    return getattr(module, class_name)
+
+
 def lookups_for_field(model_field):
     """
     Generates a list of all possible lookup expressions for a model field.

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'djangorestframework',
-        'django-filter>=0.15.0',
+        'django-filter>=1.0.0',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -54,7 +54,6 @@ class BackendTest(APITestCase):
             <p>
                 <label for="id_username">Username:</label>
                 <input id="id_username" name="username" type="text" />
-                <span class="helptext">Filter</span>
             </p>
             <button type="submit" class="btn btn-primary">Submit</button>
         </form>

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -343,7 +343,7 @@ class FilterExclusionTests(TestCase):
         }
 
         filterset = TagFilter(GET, queryset=Tag.objects.all())
-        requested_filters = filterset.get_filters()
+        requested_filters = filterset.expand_filters()
 
         self.assertTrue(requested_filters['name__contains!'].exclude)
 
@@ -357,7 +357,7 @@ class FilterExclusionTests(TestCase):
         }
 
         filterset = TagFilter(GET, queryset=Tag.objects.all())
-        requested_filters = filterset.get_filters()
+        requested_filters = filterset.expand_filters()
 
         self.assertFalse(requested_filters['name__contains'].exclude)
         self.assertTrue(requested_filters['name__contains!'].exclude)
@@ -368,7 +368,7 @@ class FilterExclusionTests(TestCase):
         }
 
         filterset = BlogPostFilter(GET, queryset=BlogPost.objects.all())
-        requested_filters = filterset.get_filters()
+        requested_filters = filterset.expand_filters()
 
         self.assertTrue(requested_filters['tags__name__contains!'].exclude)
 


### PR DESCRIPTION
This makes drf-filters compatible w/ the 1.0 release of django-filter. Fixes #143.

Changes:
- Adds `AutoFilter` as a common base class for `RelatedFilter` and `AllLookupsFilter`. The name reflects the filter auto-generation capabilities of the `FilterSet` w/ `Meta.fields`. 
- `get_filters()` => `expand_filters()`. This is a breaking change that is necessary due to the underlying API change in django-filter. 
- Moved `import_class` to utils
- Made `RelatedFilter` compatible w/ the new `get_queryset()` on the underlying `ModelChoiceFilter`.
- Refactored the metaclass to be compatible.