### PR TITLE
Use more secure default for RelatedFilter.queryset

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,7 +113,7 @@ You can easily traverse multiple relationships when filtering by using ``Related
 
 
     class DepartmentFilter(filters.FilterSet):
-        manager = filters.RelatedFilter(ManagerFilter, name='manager')
+        manager = filters.RelatedFilter(ManagerFilter, name='manager', queryset=Manager.objects.all())
 
         class Meta:
             model = Department
@@ -121,7 +121,7 @@ You can easily traverse multiple relationships when filtering by using ``Related
 
 
     class CompanyFilter(filters.FilterSet):
-        department = filters.RelatedFilter(DepartmentFilter, name='department')
+        department = filters.RelatedFilter(DepartmentFilter, name='department', queryset=Department.objects.all())
 
         class Meta:
             model = Company
@@ -146,7 +146,7 @@ Recursive relations are also supported. It may be necessary to specify the full 
 
     class PersonFilter(filters.FilterSet):
         name = filters.AllLookupsFilter(name='name')
-        best_friend = filters.RelatedFilter('people.views.PersonFilter', name='best_friend')
+        best_friend = filters.RelatedFilter('people.views.PersonFilter', name='best_friend', queryset=Person.objects.all())
 
         class Meta:
             model = Person
@@ -185,7 +185,7 @@ to all filter classes. It incorporates some of the implementation details of the
             return qs.filter(**{lookup_expr: isnull})
 
     class AuthorFilter(filters.FilterSet):
-        posts = filters.RelatedFilter('PostFilter')
+        posts = filters.RelatedFilter('PostFilter', queryset=Post.objects.all())
 
         class Meta:
             model = Author
@@ -285,7 +285,7 @@ You cannot combine ``AllLookupsFilter`` with ``RelatedFilter`` as the filter nam
 .. code-block:: python
 
     class ProductFilter(filters.FilterSet):
-        manufacturer = filters.RelatedFilter('ManufacturerFilter')
+        manufacturer = filters.RelatedFilter('ManufacturerFilter', queryset=Manufacturer.objects.all())
         manufacturer = filters.AllLookupsFilter()
 
 To work around this, you have the following options:
@@ -293,7 +293,7 @@ To work around this, you have the following options:
 .. code-block:: python
 
     class ProductFilter(filters.FilterSet):
-        manufacturer = filters.RelatedFilter('ManufacturerFilter')
+        manufacturer = filters.RelatedFilter('ManufacturerFilter', queryset=Manufacturer.objects.all())
 
         class Meta:
             model = Product
@@ -304,7 +304,7 @@ To work around this, you have the following options:
     # or
 
     class ProductFilter(filters.FilterSet):
-        manufacturer = filters.RelatedFilter('ManufacturerFilter', lookups='__all__')  # `lookups` also accepts a list
+        manufacturer = filters.RelatedFilter('ManufacturerFilter', queryset=Manufacturer.objects.all(), lookups='__all__')  # `lookups` also accepts a list
 
         class Meta:
             model = Product
@@ -326,7 +326,7 @@ and ``FilterSet``s from either package are compatible with the other's DRF backe
         ...
 
     class DRFFilter(rest_framework_filters.FilterSet):
-        vanilla = rest_framework_filters.RelatedFilter(filterset=VanillaFilter)
+        vanilla = rest_framework_filters.RelatedFilter(filterset=VanillaFilter, queryset=...)
 
 
     # invalid
@@ -334,7 +334,7 @@ and ``FilterSet``s from either package are compatible with the other's DRF backe
         ...
 
     class VanillaFilter(django_filters.FilterSet):
-        drf = rest_framework_filters.RelatedFilter(filterset=DRFFilter)
+        drf = rest_framework_filters.RelatedFilter(filterset=DRFFilter, queryset=...)
 
 
 Caveats & Limitations

--- a/README.rst
+++ b/README.rst
@@ -140,6 +140,25 @@ Example filter calls:
     /api/companies?department__name=Accounting
     /api/companies?department__manager__name__startswith=Bob
 
+``queryset`` callables
+""""""""""""""""""""""
+
+Since ``RelatedFilter`` is a subclass of ``ModelChoiceFilter``, the ``queryset`` argument supports callable behavior.
+In the following example, the set of departments is restricted to those in the user's company.
+
+.. code-block:: python
+
+    def departments(request):
+        company = request.user.company
+        return company.department_set.all()
+
+    class EmployeeFilter(filters.FilterSet):
+        department = filters.RelatedFilter(filterset=DepartmentFilter, queryset=departments)
+        ...
+
+Recursive relationships
+"""""""""""""""""""""""
+
 Recursive relations are also supported. It may be necessary to specify the full module path.
 
 .. code-block:: python
@@ -379,6 +398,22 @@ The recommended solutions are to either:
 
     ?publish_date__range=2016-01-01,2016-02-01
 
+
+Migrating to 1.0
+----------------
+
+``RelatedFilter.queryset`` now required
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The related filterset's model is no longer used to provide the default value for ``RelatedFilter.queryset``. This
+change reduces the chance of unintentionally exposing data in the rendered filter forms. You must now explicitly
+provide the ``queryset`` argument, or override the ``get_queryset()`` method (see `queryset callables`_).
+
+
+``get_filters()`` renamed to ``expand_filters()``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+django-filter has add a ``get_filters()`` classmethod to it's API, so this method has been renamed.
 
 License
 -------

--- a/rest_framework_filters/filters.py
+++ b/rest_framework_filters/filters.py
@@ -38,9 +38,9 @@ class RelatedFilter(AutoFilter, ModelChoiceFilter):
 
     def get_queryset(self, request):
         queryset = super(RelatedFilter, self).get_queryset(request)
-        if queryset is not None:
-            return queryset
-        return self.filterset._meta.model._default_manager.all()
+        assert queryset is not None, \
+            "Expected `.get_queryset()` to return a `QuerySet`, but got `None`."
+        return queryset
 
 
 class AllLookupsFilter(AutoFilter):

--- a/tests/testapp/filters.py
+++ b/tests/testapp/filters.py
@@ -48,7 +48,7 @@ class UserFilterWithAll(FilterSet):
 
 class NoteFilterWithRelated(FilterSet):
     title = filters.CharFilter(name='title')
-    author = RelatedFilter(UserFilter, name='author')
+    author = RelatedFilter(UserFilter, name='author', queryset=User.objects.all())
 
     class Meta:
         model = Note
@@ -57,7 +57,7 @@ class NoteFilterWithRelated(FilterSet):
 
 class NoteFilterWithRelatedAll(FilterSet):
     title = filters.CharFilter(name='title')
-    author = RelatedFilter(UserFilterWithAll, name='author')
+    author = RelatedFilter(UserFilterWithAll, name='author', queryset=User.objects.all())
 
     class Meta:
         model = Note
@@ -66,7 +66,7 @@ class NoteFilterWithRelatedAll(FilterSet):
 
 class NoteFilterWithRelatedAllDifferentFilterName(FilterSet):
     title = filters.CharFilter(name='title')
-    writer = RelatedFilter(UserFilterWithAll, name='author')
+    writer = RelatedFilter(UserFilterWithAll, name='author', queryset=User.objects.all())
 
     class Meta:
         model = Note
@@ -75,7 +75,7 @@ class NoteFilterWithRelatedAllDifferentFilterName(FilterSet):
 
 class PostFilter(FilterSet):
     # Used for Related filter and Filter.method regression tests
-    note = RelatedFilter(NoteFilterWithRelatedAll, name='note')
+    note = RelatedFilter(NoteFilterWithRelatedAll, name='note', queryset=Note.objects.all())
     date_published = filters.AllLookupsFilter()
     is_published = filters.BooleanFilter(name='date_published', method='filter_is_published')
 
@@ -96,7 +96,7 @@ class PostFilter(FilterSet):
 
 class CoverFilterWithRelatedMethodFilter(FilterSet):
     comment = filters.CharFilter(name='comment')
-    post = RelatedFilter(PostFilter, name='post')
+    post = RelatedFilter(PostFilter, name='post', queryset=Post.objects.all())
 
     class Meta:
         model = Cover
@@ -105,7 +105,7 @@ class CoverFilterWithRelatedMethodFilter(FilterSet):
 
 class CoverFilterWithRelated(FilterSet):
     comment = filters.CharFilter(name='comment')
-    post = RelatedFilter(PostFilter, name='post')
+    post = RelatedFilter(PostFilter, name='post', queryset=Post.objects.all())
 
     class Meta:
         model = Cover
@@ -114,7 +114,7 @@ class CoverFilterWithRelated(FilterSet):
 
 class PageFilterWithRelated(FilterSet):
     title = filters.CharFilter(name='title')
-    previous_page = RelatedFilter(PostFilter, name='previous_page')
+    previous_page = RelatedFilter(PostFilter, name='previous_page', queryset=Post.objects.all())
 
     class Meta:
         model = Page
@@ -131,7 +131,7 @@ class TagFilter(FilterSet):
 
 class BlogPostFilter(FilterSet):
     title = filters.CharFilter(name='title')
-    tags = RelatedFilter(TagFilter, name='tags')
+    tags = RelatedFilter(TagFilter, name='tags', queryset=Tag.objects.all())
 
     class Meta:
         model = BlogPost
@@ -186,7 +186,7 @@ class BFilter(FilterSet):
 
 class PersonFilter(FilterSet):
     name = AllLookupsFilter(name='name')
-    best_friend = RelatedFilter('tests.testapp.filters.PersonFilter', name='best_friend')
+    best_friend = RelatedFilter('tests.testapp.filters.PersonFilter', name='best_friend', queryset=Person.objects.all())
 
     class Meta:
         model = Person


### PR DESCRIPTION
The secure default here is to simply remove the current default handling for the `queryset` argument. The underlying form field will complain about the lack of a `queryset` if it's not provided, so this forces the user to explicitly add it to the filter instance. 

Ref #100. This is only a partial fix, as this only restricts the displayed choices for the relationship. This does not prevent against joins that might leak data.

This is a breaking change.