### PR TITLE
restrict version of django-filters to <2.0 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'djangorestframework',
-        'django-filter>=1.0.0',
+        'django-filter>=1.0.0,<2.0',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
We had a problem with a prior version of django-rest-framework-filters 0.8.0 which installed an incompatible version of django-filters (1.0.0).