### PR TITLE
Version lock django-filter<1.0, due to API incompatibilities

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'djangorestframework',
-        'django-filter>=0.15.0',
+        'django-filter>=0.15.0,<1.0',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Ref #147. 