### PR TITLE
Update changelog for 0.9.1 release and recent changes on master

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Unreleased:
 -----------
 
+* Add support for django-filter 1.0
+
+v0.9.1:
+-------
+
+* #128 Fix all lookups handling for related fields
+* #129 Fix backend template rendering
+* #148 Version lock django-filter<1.0 due to API incompatibilities
+
 v0.9.0:
 -------
 


### PR DESCRIPTION
Fixes #151 and also makes it clearer that django-filter 1.0 is not yet supported in a published release.

The latter caused some confusion, since I'd manually updated django-filter to 1.0.1 in the pinned deps in requirements.txt and then started getting:

> ImportError: Could not import 'rest_framework_filters.backends.DjangoFilterBackend' for API setting 'DEFAULT_FILTER_BACKENDS'. AttributeError: 'NoneType' object has no attribute 'FilterSet'.

(Time to start running pip v9's new `check` feature as part of CI, since it would have caught the conflicting requirement specifiers.)