### PR TITLE
Fix request-based filtering

### DIFF
--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -123,7 +123,7 @@ class FilterSet(six.with_metaclass(FilterSetMetaclass, rest_framework.FilterSet)
             if isinstance(f, filters.RelatedFilter) and filter_name in related_data:
                 subset_data = related_data[filter_name]
                 subset_class = f.filterset.get_subset(subset_data)
-                filterset = subset_class(data=subset_data)
+                filterset = subset_class(data=subset_data, request=self.request)
 
                 # modify filter names to account for relationship
                 for related_name, related_f in six.iteritems(filterset.expand_filters()):

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,5 +1,6 @@
 
 from rest_framework.test import APITestCase, APIRequestFactory
+from rest_framework_filters import FilterSet
 
 from .testapp import models, views
 
@@ -58,3 +59,25 @@ class BackendTest(APITestCase):
             <button type="submit" class="btn btn-primary">Submit</button>
         </form>
         """)
+
+    def test_request_obj_is_passed(self):
+        """
+        Ensure that the request object is passed from the backend to the filterset.
+        See: https://github.com/philipn/django-rest-framework-filters/issues/149
+        """
+        class RequestCheck(FilterSet):
+            def __init__(self, *args, **kwargs):
+                super(RequestCheck, self).__init__(*args, **kwargs)
+                assert self.request is not None
+
+            class Meta:
+                model = models.User
+                fields = ['username']
+
+        class ViewSet(views.FilterFieldsUserViewSet):
+            filter_class = RequestCheck
+
+        view = ViewSet(action_map={})
+        backend = view.filter_backends[0]
+        request = view.initialize_request(factory.get('/'))
+        backend().filter_queryset(request, view.get_queryset(), view)

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -349,6 +349,28 @@ class RelatedFilterTests(TestCase):
         msg = str(excinfo.exception)
         self.assertEqual("Expected `.get_queryset()` to return a `QuerySet`, but got `None`.", msg)
 
+    def test_relatedfilter_request_is_passed(self):
+        class RequestCheck(FilterSet):
+            def __init__(self, *args, **kwargs):
+                super(RequestCheck, self).__init__(*args, **kwargs)
+                assert self.request is not None
+
+            class Meta:
+                model = User
+                fields = ['username']
+
+        class NoteFilter(FilterSet):
+            author = filters.RelatedFilter(RequestCheck, name='author')
+
+            class Meta:
+                model = Note
+                fields = []
+
+        GET = {'author__username': 'user2'}
+
+        # should pass
+        NoteFilter(GET, queryset=Note.objects.all(), request=object()).qs
+
 
 class MiscTests(TestCase):
     def test_multiwidget_incompatibility(self):


### PR DESCRIPTION
This aims to fix #149. 

- [x] Tests should demonstrate failure for the main filterset and related filtersets
- [x] The backend needs to initialize the filterset with the request
- [x] The related filtersets need to be initialized with the parent's filterset
