### PR TITLE
Fix packaging+README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -335,8 +335,8 @@ Can I mix and match ``django-filter`` and ``django-rest-framework-filters``?
 Yes you can. ``django-rest-framework-filters`` is simply an extension of ``django-filter``. Note
 that ``RelatedFilter`` and other ``django-rest-framework-filters`` features are designed to work
 with ``rest_framework_filters.FilterSet`` and will not function on a ``django_filters.FilterSet``.
-However, the target ``RelatedFilter.filterset`` may point to a ``FilterSet`` from either package
-and ``FilterSet``s from either package are compatible with the other's DRF backend.
+However, the target ``RelatedFilter.filterset`` may point to a ``FilterSet`` from either package,
+and both ``FilterSet`` implementations are compatible with the other's DRF backend.
 
 .. code-block:: python
 

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,10 @@ from setuptools import setup
 import os
 
 
+with open('README.rst') as f:
+    README = f.read()
+
+
 def get_packages(package):
     """
     Return root package and all sub-packages.
@@ -35,6 +39,7 @@ setup(
     version='0.10.1',
     url='http://github.com/philipn/django-rest-framework-filters',
     license='MIT',
+    long_description=README,
     description='Better filtering for Django REST Framework',
     author='Philip Neustrom',
     author_email='philipn@gmail.com',


### PR DESCRIPTION
Reading in the README and setting it to `long_description` allows rendering failures to be detected by `setup.py check -r -s`.

Fixes #165.