### PR TITLE
Remove subset classes

### DIFF
--- a/rest_framework_filters/backends.py
+++ b/rest_framework_filters/backends.py
@@ -1,5 +1,5 @@
-
 from contextlib import contextmanager
+
 from django_filters.rest_framework import backends
 
 from .filterset import FilterSet
@@ -12,25 +12,6 @@ def noop(self):
 
 class DjangoFilterBackend(backends.DjangoFilterBackend):
     default_filter_set = FilterSet
-
-    @contextmanager
-    def patch_for_filtering(self, request):
-        """
-        Patch `get_filter_class()` to get the subset based on the request params
-        """
-        original = self.get_filter_class
-
-        def get_subset_class(view, queryset=None):
-            filter_class = original(view, queryset)
-
-            if filter_class and hasattr(filter_class, 'get_subset'):
-                filter_class = filter_class.get_subset(request.query_params)
-
-            return filter_class
-
-        self.get_filter_class = get_subset_class
-        yield
-        self.get_filter_class = original
 
     @contextmanager
     def patch_for_rendering(self, request):
@@ -49,12 +30,6 @@ class DjangoFilterBackend(backends.DjangoFilterBackend):
         self.get_filter_class = get_filter_class
         yield
         self.get_filter_class = original
-
-    def filter_queryset(self, request, queryset, view):
-        # patching the behavior of `get_filter_class()` in this method allows
-        # us to avoid maintenance issues with code duplication.
-        with self.patch_for_filtering(request):
-            return super(DjangoFilterBackend, self).filter_queryset(request, queryset, view)
 
     def to_html(self, request, queryset, view):
         # patching the behavior of `get_filter_class()` in this method allows

--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -61,8 +61,7 @@ class FilterSetMetaclass(filterset.FilterSetMetaclass):
     @property
     def related_filters(self):
         # check __dict__ instead of use hasattr. we *don't* want to check
-        # parents for existence of existing cache. eg, we do not want
-        # FilterSet.get_subset([...]) to return the same cache.
+        # parents for existence of existing cache.
         if '_related_filters' not in self.__dict__:
             self._related_filters = OrderedDict([
                 (name, f) for name, f in self.base_filters.items()
@@ -72,10 +71,17 @@ class FilterSetMetaclass(filterset.FilterSetMetaclass):
 
 
 class FilterSet(rest_framework.FilterSet, metaclass=FilterSetMetaclass):
-    _subset_cache = {}
 
-    def __init__(self, *args, **kwargs):
-        super(FilterSet, self).__init__(*args, **kwargs)
+    def __init__(self, data=None, queryset=None, *, request=None, prefix=None, **kwargs):
+        # Filter the `base_filters` by the desired filter subset. This reduces the cost
+        # of initialization by reducing the number of filters that are deepcopied.
+        subset = self.get_filter_subset(data or {})
+        if subset:
+            self.base_filters = OrderedDict([
+                (k, v) for k, v in self.base_filters.items() if k in subset
+            ])
+
+        super(FilterSet, self).__init__(data, queryset, request=request, prefix=prefix, **kwargs)
 
         self.expanded_filters = self.expand_filters()
 
@@ -131,8 +137,7 @@ class FilterSet(rest_framework.FilterSet, metaclass=FilterSetMetaclass):
             # include filters from related subsets
             if isinstance(f, filters.RelatedFilter) and filter_name in related_data:
                 subset_data = related_data[filter_name]
-                subset_class = f.filterset.get_subset(subset_data)
-                filterset = subset_class(data=subset_data, request=self.request)
+                filterset = f.filterset(data=subset_data, request=self.request)
 
                 # modify filter names to account for relationship
                 for related_name, related_f in filterset.expand_filters().items():
@@ -209,56 +214,20 @@ class FilterSet(rest_framework.FilterSet, metaclass=FilterSetMetaclass):
         return None, None
 
     @classmethod
-    def get_subset(cls, params):
+    def get_filter_subset(cls, params):
         """
-        Returns a FilterSubset class that contains the subset of filters
-        specified in the requested `params`. This is useful for creating
-        FilterSets that traverse relationships, as it helps to minimize
-        the deepcopy overhead incurred when instantiating the FilterSet.
+        Returns a subset of filter names that should be initialized by the
+        FilterSet, dependent on the requested `params`. This is useful when
+        traversing FilterSet relationships, as it helps to minimize deepcopy
+        overhead incurred when instantiating related FilterSets.
         """
         # Determine names of filters from query params and remove empty values.
         # param names that traverse relations are translated to just the local
         # filter names. eg, `author__username` => `author`. Empty values are
         # removed, as they indicate an unknown field eg, author__foobar__isnull
-        filter_names = [cls.get_param_filter_name(param) for param in params]
-        filter_names = [f for f in filter_names if f is not None]
-
-        # attempt to retrieve related filterset subset from the cache
-        key = cls.cache_key(filter_names)
-        subset_class = cls.cache_get(key)
-
-        # if no cached subset, then derive base_filters and create new subset
-        if subset_class is not None:
-            return subset_class
-
-        class FilterSubsetMetaclass(type(cls)):
-            def __new__(cls, name, bases, attrs):
-                new_class = super(FilterSubsetMetaclass, cls).__new__(cls, name, bases, attrs)
-                new_class.base_filters = OrderedDict([
-                    (param, base_filter) for param, base_filter
-                    in new_class.base_filters.items()
-                    if param in filter_names
-                ])
-                return new_class
-
-        class FilterSubset(cls, metaclass=FilterSubsetMetaclass):
-            pass
-
-        FilterSubset.__name__ = str('%sSubset' % (cls.__name__, ))
-        cls.cache_set(key, FilterSubset)
-        return FilterSubset
-
-    @classmethod
-    def cache_key(cls, filter_names):
-        return '%sSubset-%s' % (cls.__name__, '-'.join(sorted(filter_names)), )
-
-    @classmethod
-    def cache_get(cls, key):
-        return cls._subset_cache.get(key)
-
-    @classmethod
-    def cache_set(cls, key, value):
-        cls._subset_cache[key] = value
+        filter_names = {cls.get_param_filter_name(param) for param in params}
+        filter_names = {f for f in filter_names if f is not None}
+        return filter_names
 
     @contextmanager
     def requested_filters(self):

--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -150,16 +150,16 @@ class FilterSet(rest_framework.FilterSet, metaclass=FilterSetMetaclass):
         ex::
 
             # regular attribute filters
-            name = FilterSet.get_param_filter_name('email')
-            assert name == 'email'
+            >>> FilterSet.get_param_filter_name('email')
+            'email'
 
             # exclusion filters
-            name = FilterSet.get_param_filter_name('email!')
-            assert name == 'email'
+            >>> FilterSet.get_param_filter_name('email!')
+            'email'
 
             # related filters
-            name = FilterSet.get_param_filter_name('author__email')
-            assert name == 'author'
+            >>> FilterSet.get_param_filter_name('author__email')
+            'author'
 
         """
         # Attempt to match against filters with lookups first. (username__endswith)
@@ -174,7 +174,7 @@ class FilterSet(rest_framework.FilterSet, metaclass=FilterSetMetaclass):
         related_filters = cls.related_filters.keys()
 
         # preference more specific filters. eg, `note__author` over `note`.
-        for name in sorted(related_filters)[::-1]:
+        for name in reversed(sorted(related_filters)):
             # we need to match against '__' to prevent eager matching against
             # like names. eg, note vs note2. Exact matches are handled above.
             if param.startswith("%s%s" % (name, LOOKUP_SEP)):
@@ -187,19 +187,17 @@ class FilterSet(rest_framework.FilterSet, metaclass=FilterSetMetaclass):
 
         ex::
 
-            name, param = FilterSet.get_filter_name('author__email__foobar')
-            assert name == 'author'
-            assert param = 'email__foobar'
+            >>> FilterSet.get_related_filter_param('author__email__foobar')
+            ('author', 'email__foobar')
 
-            name, param = FilterSet.get_filter_name('author')
-            assert name is None
-            assert param is None
+            >>> FilterSet.get_related_filter_param('author')
+            (None, None)
 
         """
         related_filters = cls.related_filters.keys()
 
         # preference more specific filters. eg, `note__author` over `note`.
-        for name in sorted(related_filters)[::-1]:
+        for name in reversed(sorted(related_filters)):
             # we need to match against '__' to prevent eager matching against
             # like names. eg, note vs note2. Exact matches are handled above.
             if param.startswith("%s%s" % (name, LOOKUP_SEP)):
@@ -237,8 +235,8 @@ class FilterSet(rest_framework.FilterSet, metaclass=FilterSetMetaclass):
             def __new__(cls, name, bases, attrs):
                 new_class = super(FilterSubsetMetaclass, cls).__new__(cls, name, bases, attrs)
                 new_class.base_filters = OrderedDict([
-                    (param, f)
-                    for param, f in new_class.base_filters.items()
+                    (param, base_filter) for param, base_filter
+                    in new_class.base_filters.items()
                     if param in filter_names
                 ])
                 return new_class

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -319,29 +319,20 @@ class RelatedFilterTests(TestCase):
         self.assertEqual(len(list(f.qs)), 4)
 
     def test_related_filters_caching(self):
-        filters = PostFilter.related_filters
+        class ChildFilter(PostFilter):
+            foo = filters.RelatedFilter(PostFilter)
 
-        self.assertEqual(len(filters), 1)
-        self.assertIn('note', filters)
+        self.assertEqual(len(PostFilter.related_filters), 1)
+        self.assertIn('note', PostFilter.related_filters)
         self.assertIn('_related_filters', PostFilter.__dict__)
 
-        # subset should not use parent's cached related filters.
-        PostSubset = PostFilter.get_subset(['title'])
-        self.assertNotIn('_related_filters', PostSubset.__dict__)
+        # child filterset should not use parent's cached related filters.
+        self.assertNotIn('_related_filters', ChildFilter.__dict__)
 
-        filters = PostSubset.related_filters
-        self.assertIn('_related_filters', PostFilter.__dict__)
-
-        self.assertEqual(len(filters), 0)
-
-        # ensure subsets don't interact
-        PostSubset = PostFilter.get_subset(['note'])
-        self.assertNotIn('_related_filters', PostSubset.__dict__)
-
-        filters = PostSubset.related_filters
-        self.assertIn('_related_filters', PostFilter.__dict__)
-
-        self.assertEqual(len(filters), 1)
+        self.assertEqual(len(ChildFilter.related_filters), 2)
+        self.assertIn('note', ChildFilter.related_filters)
+        self.assertIn('foo', ChildFilter.related_filters)
+        self.assertIn('_related_filters', ChildFilter.__dict__)
 
     def test_relatedfilter_queryset_required(self):
         # Use a secure default queryset. Previous behavior was to use the default model

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -288,27 +288,24 @@ class GetRelatedFilterParamTests(TestCase):
 class FilterSubsetTests(TestCase):
 
     def test_get_subset(self):
-        filterset_class = UserFilter.get_subset(['email'])
-
-        # ensure that the class name is useful when debugging
-        self.assertEqual(filterset_class.__name__, 'UserFilterSubset')
+        filter_subset = UserFilter.get_filter_subset(['email'])
 
         # ensure that the FilterSet subset only contains the requested fields
-        self.assertIn('email', filterset_class.base_filters)
-        self.assertEqual(len(filterset_class.base_filters), 1)
+        self.assertIn('email', filter_subset)
+        self.assertEqual(len(filter_subset), 1)
 
     def test_related_subset(self):
         # related filters should only return the local RelatedFilter
-        filterset_class = NoteFilterWithRelated.get_subset(['title', 'author__email'])
+        filter_subset = NoteFilterWithRelated.get_filter_subset(['title', 'author', 'author__email'])
 
-        self.assertIn('title', filterset_class.base_filters)
-        self.assertIn('author', filterset_class.base_filters)
-        self.assertEqual(len(filterset_class.base_filters), 2)
+        self.assertIn('title', filter_subset)
+        self.assertIn('author', filter_subset)
+        self.assertEqual(len(filter_subset), 2)
 
     def test_non_filter_subset(self):
         # non-filter params should be ignored
-        filterset_class = NoteFilterWithRelated.get_subset(['foobar'])
-        self.assertEqual(len(filterset_class.base_filters), 0)
+        filter_subset = NoteFilterWithRelated.get_filter_subset(['foobar'])
+        self.assertEqual(len(filter_subset), 0)
 
     def test_metaclass_inheritance(self):
         # See: https://github.com/philipn/django-rest-framework-filters/issues/132
@@ -325,14 +322,12 @@ class FilterSubsetTests(TestCase):
                 model = Note
                 fields = ['title', 'content']
 
-        # ensure that the class name is useful when debugging
-        filterset_class = NoteFilter.get_subset(['author', 'content'])
-        self.assertEqual(filterset_class.__name__, 'NoteFilterSubset')
+        filter_subset = NoteFilter.get_filter_subset(['author', 'content'])
 
         # ensure that the FilterSet subset only contains the requested fields
-        self.assertIn('author', filterset_class.base_filters)
-        self.assertIn('content', filterset_class.base_filters)
-        self.assertEqual(len(filterset_class.base_filters), 2)
+        self.assertIn('author', filter_subset)
+        self.assertIn('content', filter_subset)
+        self.assertEqual(len(filter_subset), 2)
 
 
 class FilterOverrideTests(TestCase):


### PR DESCRIPTION
The original purpose of subset classes was to reduce the cost of deepcopy'ing by simply reducing the number of filters that need to be copied to begin with. The tradeoff then became the cost of creating these new classes, although the classes could in turn be cached in a long-lived dict. 

Regardless, this solution is overly complicated, and it's much simpler to override the `FilterSet` instance's base_filters in the initializer before the deep copy operation occurs. 

**Changes:**
- Removes Subset class creation & caching
- Removes backend method patching for subset handling.
- A few docstring changes and other minor improvements