### PR TITLE
Move 'related_filters' to type creation

### DIFF
--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -54,20 +54,15 @@ class FilterSetMetaclass(filterset.FilterSetMetaclass):
                 for gen_param, gen_f in generated_filters.items()
             ))
 
+        # Gather related filters
+        new_class.related_filters = OrderedDict([
+            (name, f) for name, f in new_class.base_filters.items()
+            if isinstance(f, filters.RelatedFilter)
+        ])
+
         new_class._meta, new_class.declared_filters = orig_meta, orig_declared
 
         return new_class
-
-    @property
-    def related_filters(self):
-        # check __dict__ instead of use hasattr. we *don't* want to check
-        # parents for existence of existing cache.
-        if '_related_filters' not in self.__dict__:
-            self._related_filters = OrderedDict([
-                (name, f) for name, f in self.base_filters.items()
-                if isinstance(f, filters.RelatedFilter)
-            ])
-        return self._related_filters
 
 
 class FilterSet(rest_framework.FilterSet, metaclass=FilterSetMetaclass):

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -318,21 +318,12 @@ class RelatedFilterTests(TestCase):
         f = NoteFilterWithRelated(GET, queryset=Note.objects.all())
         self.assertEqual(len(list(f.qs)), 4)
 
-    def test_related_filters_caching(self):
+    def test_related_filters_inheritance(self):
         class ChildFilter(PostFilter):
             foo = filters.RelatedFilter(PostFilter)
 
-        self.assertEqual(len(PostFilter.related_filters), 1)
-        self.assertIn('note', PostFilter.related_filters)
-        self.assertIn('_related_filters', PostFilter.__dict__)
-
-        # child filterset should not use parent's cached related filters.
-        self.assertNotIn('_related_filters', ChildFilter.__dict__)
-
-        self.assertEqual(len(ChildFilter.related_filters), 2)
-        self.assertIn('note', ChildFilter.related_filters)
-        self.assertIn('foo', ChildFilter.related_filters)
-        self.assertIn('_related_filters', ChildFilter.__dict__)
+        self.assertEqual(['note'], list(PostFilter.related_filters))
+        self.assertEqual(['note', 'foo'], list(ChildFilter.related_filters))
 
     def test_relatedfilter_queryset_required(self):
         # Use a secure default queryset. Previous behavior was to use the default model


### PR DESCRIPTION
It's not beneficial for `FilterSet.related_filters` to be lazily evaluated. 