### PR TITLE
Cleanup the FIlterSet Metaclass

### DIFF
--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -18,15 +18,15 @@ class FilterSetMetaclass(filterset.FilterSetMetaclass):
     def __new__(cls, name, bases, attrs):
         new_class = super(FilterSetMetaclass, cls).__new__(cls, name, bases, attrs)
 
+        # If no model is defined, skip auto filter processing
+        if new_class._meta.model is None:
+            return new_class
+
         opts = copy.deepcopy(new_class._meta)
         orig_meta = new_class._meta
 
         declared_filters = new_class.declared_filters.copy()
         orig_declared = new_class.declared_filters
-
-        # If no model is defined, skip auto filter processing
-        if not opts.model:
-            return new_class
 
         # Generate filters for auto filters
         auto_filters = OrderedDict([

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -41,6 +41,21 @@ class limit_recursion:
         sys.setrecursionlimit(self.original_limit)
 
 
+class MetaclassTests(TestCase):
+
+    def test_metamethods(self):
+        functions = [
+            'expand_auto_filters',
+            'get_auto_filters',
+            'get_related_filters',
+        ]
+
+        for func in functions:
+            with self.subTest(func=func):
+                self.assertTrue(hasattr(UserFilter, func))
+                self.assertFalse(hasattr(UserFilter(), func))
+
+
 class LookupsFilterTests(TestCase):
     """
     Test basic filter construction for `AllLookupsFilter`, '__all__', and `RelatedFilter.lookups`.


### PR DESCRIPTION
Reorganizes the metaclass into a few metamethods.

- Improves readability, as the various bits of functionality aren't quite as intertwined.
- The metamethods can actually be overridden by their FiltreSet class, although it's not clear if this will be all that useful. 