### PR TITLE
[wip] Rework related filtering

### DIFF
--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -2,6 +2,7 @@ import copy
 from collections import OrderedDict
 from contextlib import contextmanager
 
+from django.db.models import Subquery
 from django.db.models.constants import LOOKUP_SEP
 from django.http.request import QueryDict
 from django_filters import filterset, rest_framework
@@ -270,6 +271,7 @@ class FilterSet(rest_framework.FilterSet, metaclass=FilterSetMetaclass):
         """
         for field_name, related_filterset in self.related_filtersets.items():
             lookup_expr = LOOKUP_SEP.join([field_name, 'in'])
-            queryset = queryset.filter(**{lookup_expr: related_filterset.qs})
+            subquery = Subquery(related_filterset.qs.values('pk'))
+            queryset = queryset.filter(**{lookup_expr: subquery})
 
         return queryset

--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -250,7 +250,17 @@ class FilterSet(rest_framework.FilterSet, metaclass=FilterSetMetaclass):
 
     def get_form_class(self):
         with self.override_filters():
-            return super(FilterSet, self).get_form_class()
+            class Form(super(FilterSet, self).get_form_class()):
+                def clean(form):
+                    cleaned_data = super(Form, form).clean()
+
+                    for field_name, related_filterset in self.related_filtersets.items():
+                        for key, error in related_filterset.form.errors.items():
+                            self.form.errors[LOOKUP_SEP.join([field_name, key])] = error
+
+                    return cleaned_data
+
+            return Form
 
     def filter_related_filtersets(self, queryset):
         """

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -1,5 +1,6 @@
 import sys
 
+from django.http.request import QueryDict
 from django.test import TestCase
 from django_filters.filters import BaseInFilter
 from rest_framework.test import APIRequestFactory
@@ -253,22 +254,31 @@ class GetParamFilterNameTests(TestCase):
         self.assertEqual('note2', name)
 
 
-class GetRelatedFilterParamTests(TestCase):
+class GetRelatedDataTests(TestCase):
 
     def test_regular_filter(self):
-        name, param = NoteFilterWithRelated.get_related_filter_param('title')
-        self.assertIsNone(name)
-        self.assertIsNone(param)
+        params = NoteFilterWithRelated.get_related_data({'title': ''})
+        self.assertEqual(params, {})
 
     def test_related_filter_exact(self):
-        name, param = NoteFilterWithRelated.get_related_filter_param('author')
-        self.assertIsNone(name)
-        self.assertIsNone(param)
+        params = NoteFilterWithRelated.get_related_data({'author': ''})
+        self.assertEqual(params, {})
 
-    def test_related_filter_param(self):
-        name, param = NoteFilterWithRelated.get_related_filter_param('author__email')
-        self.assertEqual('author', name)
-        self.assertEqual('email', param)
+    def test_related_filters(self):
+        params = NoteFilterWithRelated.get_related_data({'author__email': ''})
+        self.assertEqual(params, {'author': {'email': ['']}})
+
+    def test_multiple_related_filters(self):
+        params = NoteFilterWithRelated.get_related_data({
+            'author__username': '',
+            'author__is_active': '',
+            'author__email': '',
+        })
+        self.assertEqual(params, {'author': {
+            'email': [''],
+            'is_active': [''],
+            'username': [''],
+        }})
 
     def test_name_hiding(self):
         class PostFilterNameHiding(PostFilter):
@@ -280,21 +290,52 @@ class GetRelatedFilterParamTests(TestCase):
                 model = Post
                 fields = []
 
-        name, param = PostFilterNameHiding.get_related_filter_param('note__author__email')
-        self.assertEqual('note__author', name)
-        self.assertEqual('email', param)
+        params = PostFilterNameHiding.get_related_data({'note__author__email': ''})
+        self.assertEqual(params, {'note__author': {'email': ['']}})
 
-        name, param = PostFilterNameHiding.get_related_filter_param('note__title')
-        self.assertEqual('note', name)
-        self.assertEqual('title', param)
+        params = PostFilterNameHiding.get_related_data({'note__title': ''})
+        self.assertEqual(params, {'note': {'title': ['']}})
 
-        name, param = PostFilterNameHiding.get_related_filter_param('note2__title')
-        self.assertEqual('note2', name)
-        self.assertEqual('title', param)
+        params = PostFilterNameHiding.get_related_data({'note2__title': ''})
+        self.assertEqual(params, {'note2': {'title': ['']}})
 
-        name, param = PostFilterNameHiding.get_related_filter_param('note2__author')
-        self.assertEqual('note2', name)
-        self.assertEqual('author', param)
+        params = PostFilterNameHiding.get_related_data({'note2__author': ''})
+        self.assertEqual(params, {'note2': {'author': ['']}})
+
+        # combined
+        params = PostFilterNameHiding.get_related_data({
+            'note__author__email': '',
+            'note__title': '',
+            'note2__title': '',
+            'note2__author': '',
+        })
+
+        self.assertEqual(params, {
+            'note__author': {'email': ['']},
+            'note': {'title': ['']},
+            'note2': {
+                'title': [''],
+                'author': [''],
+            },
+        })
+
+    def test_querydict(self):
+        self.assertEqual(
+            QueryDict('a=1&a=2&b=3'),
+            {'a': ['1', '2'], 'b': ['3']}
+        )
+
+        result = {'note': {
+            'author__email': ['a'],
+            'title': ['b', 'c'],
+        }}
+
+        query = QueryDict('note__author__email=a&note__title=b&note__title=c')
+        self.assertEqual(PostFilter.get_related_data(query), result)
+
+        # QueryDict-like dictionary w/ multiple values for a param (a la m2m)
+        query = {'note__author__email': 'a', 'note__title': ['b', 'c']}
+        self.assertEqual(PostFilter.get_related_data(query), result)
 
 
 class GetFilterSubsetTests(TestCase):

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -458,9 +458,9 @@ class FilterExclusionTests(TestCase):
         }
 
         filterset = BlogPostFilter(GET, queryset=BlogPost.objects.all())
-        requested_filters = filterset.request_filters
+        requested_filters = filterset.related_filtersets['tags'].request_filters
 
-        self.assertTrue(requested_filters['tags__name__contains!'].exclude)
+        self.assertTrue(requested_filters['name__contains!'].exclude)
 
     def test_exclusion_results(self):
         GET = {


### PR DESCRIPTION
This is a first pass at solving #99 & #100. I'm mostly happy with the state of this, but there are a lot of tests that need to be written. Additionally,  displaying related forms is not possible with this implementation, so I'm trying a second approach.

That all said, here is what this PR would enable:
- Correct behavior when filtering across to-many relationships ([ref](https://docs.djangoproject.com/en/1.11/topics/db/queries/#spanning-multi-valued-relationships)).
- Related Filters can now enforce queryset restrictions. (eg, only display related articles that have been published or are authored by the request user).
- No longer necessary to customize method filters (previously requires munging the `name`).
- Filtering on *related* annotations.

