### PR TITLE
Add ComplexFilterBackend

### DIFF
--- a/rest_framework_filters/backends.py
+++ b/rest_framework_filters/backends.py
@@ -1,7 +1,11 @@
 from contextlib import contextmanager
 
+from django.http import QueryDict
 from django_filters.rest_framework import backends
+from rest_framework.exceptions import ValidationError
+from rest_framework.request import clone_request
 
+from .complex_ops import decode_querystring_ops, OPERATORS
 from .filterset import FilterSet
 
 
@@ -36,3 +40,31 @@ class DjangoFilterBackend(backends.DjangoFilterBackend):
         # us to avoid maintenance issues with code duplication.
         with self.patch_for_rendering(request):
             return super(DjangoFilterBackend, self).to_html(request, queryset, view)
+
+
+class ComplexFilterBackend(DjangoFilterBackend):
+    complex_filter_param = 'filters'
+
+    def filter_queryset(self, request, original, view):
+        parent = super(ComplexFilterBackend, self)
+
+        if self.complex_filter_param not in request.query_params:
+            return parent.filter_queryset(request, original, view)
+
+        encoded_querystring = request.query_params[self.complex_filter_param]
+        try:
+            querystring_ops = decode_querystring_ops(encoded_querystring)
+        except ValidationError as exc:
+            raise ValidationError({self.complex_filter_param: exc.detail})
+
+        queryset = original
+        queryset_op = OPERATORS['&']  # effectively a noop
+
+        for querystring, op in querystring_ops:
+            cloned = clone_request(request, request.method)
+            cloned._request.GET = QueryDict(querystring)
+
+            queryset = queryset_op(queryset, parent.filter_queryset(cloned, original, view))
+            queryset_op = OPERATORS.get(op)
+
+        return queryset

--- a/rest_framework_filters/complex_ops.py
+++ b/rest_framework_filters/complex_ops.py
@@ -78,3 +78,17 @@ def decode_complex_ops(encoded_querystring, operators=None, negation=True):
         raise ValidationError(errors)
 
     return results
+
+
+def combine_complex_queryset(querysets, complex_ops, negation=True):
+    # Negate querysets
+    for queryset, op in zip(querysets, complex_ops):
+        if negation and op.negate:
+            queryset.query.where.negate()
+
+    # Combine querysets
+    combined = querysets[0]
+    for queryset, op in zip(querysets[1:], complex_ops[:-1]):
+        combined = op.op(combined, queryset)
+
+    return combined

--- a/rest_framework_filters/complex_ops.py
+++ b/rest_framework_filters/complex_ops.py
@@ -1,0 +1,67 @@
+import re
+from urllib.parse import unquote
+
+from django.db.models import Q
+from django.utils.translation import ugettext as _
+
+from rest_framework.serializers import ValidationError
+
+
+# see: https://regex101.com/r/9MiZ7n/7
+# essentially we want to match groups of "(<encoded querystring>)<set op>"
+# special thanks to @JohnDoe2 on the #regex IRC channel!
+QUERYSTRING_OP_RE = re.compile(r'\(([^)]+)\)([^()]*)?')
+
+OPERATORS = {
+    '&': lambda a, b: a & b,
+    '|': lambda a, b: a | b,
+    '-': lambda a, b: a & ~Q(b),
+}
+
+
+def decode_querystring_ops(encoded_querystring):
+    """
+    Returns a list of (querystring, op) pairs given the `encoded_querystring`.
+
+    This function will raise a `ValidationError`s if:
+    - the leading decoded character is not an opening '('
+    - the set operators do not match (&, |, or -)
+    - there is a trailing operator after the last querysting
+
+    Ex::
+
+        # unencoded query: (a=1) & (b=2) | (c=3) - (d=4)
+        >>> s = '%28a%253D1%29%26%28b%253D2%29%7C%28c%253D3%29-%28d%253D4%29'
+        >>> decode_querystring_ops(s)
+        [
+            ('a=1', '&'),
+            ('b=2', '|'),
+            ('c=3', '-'),
+            ('d=4', ''),
+        ]
+    """
+    # decode into: (a%3D1)&(b%3D2)|(c%3D3)-(d%3D4)
+    decoded_querystring = unquote(encoded_querystring)
+    result = QUERYSTRING_OP_RE.findall(decoded_querystring)
+
+    if not result:
+        raise ValidationError(
+            _("Unable to parse querystring. Decoded: '%(decoded)s'.") % {
+                'decoded': decoded_querystring
+            }
+        )
+
+    errors = []
+    for __, op in result[:-1]:
+        if op.strip() not in OPERATORS:
+            msg = _("Invalid querystring operator. Matched: '%(op)s'.")
+            errors.append(msg % {'op': op})
+
+    if result[-1][1].strip() != '':
+        msg = _("Final querystring must not have an operator. Matched: '%(op)s'.")
+        errors.append(msg % {'op': result[-1][1]})
+
+    if errors:
+        raise ValidationError(errors)
+
+    return [(unquote(querysting), op.strip()) for querysting, op in result]

--- a/rest_framework_filters/complex_ops.py
+++ b/rest_framework_filters/complex_ops.py
@@ -1,67 +1,80 @@
 import re
+from collections import namedtuple
 from urllib.parse import unquote
 
-from django.db.models import Q
+from django.db.models import QuerySet
 from django.utils.translation import ugettext as _
 
 from rest_framework.serializers import ValidationError
 
+from rest_framework_filters.utils import lookahead
 
-# see: https://regex101.com/r/9MiZ7n/7
-# essentially we want to match groups of "(<encoded querystring>)<set op>"
+
+# originally based on: https://regex101.com/r/5rPycz/1
+# current iteration: https://regex101.com/r/5rPycz/3
 # special thanks to @JohnDoe2 on the #regex IRC channel!
-QUERYSTRING_OP_RE = re.compile(r'\(([^)]+)\)([^()]*)?')
-
-OPERATORS = {
-    '&': lambda a, b: a & b,
-    '|': lambda a, b: a | b,
-    '-': lambda a, b: a & ~Q(b),
+# matches groups of "<negate>(<encoded querystring>)<set op>"
+COMPLEX_OP_RE = re.compile(r'()\(([^)]+)\)([^(]*?(?=\())?')
+COMPLEX_OP_NEG_RE = re.compile(r'(~?)\(([^)]+)\)([^(]*?(?=~\(|\())?')
+COMPLEX_OPERATORS = {
+    '&': QuerySet.__and__,
+    '|': QuerySet.__or__,
 }
 
+ComplexOp = namedtuple('ComplexOp', ['querystring', 'negate', 'op'])
 
-def decode_querystring_ops(encoded_querystring):
+
+def decode_complex_ops(encoded_querystring, operators=None, negation=True):
     """
-    Returns a list of (querystring, op) pairs given the `encoded_querystring`.
+    Returns a list of (querystring, negate, op) tuples that represent complex operations.
 
     This function will raise a `ValidationError`s if:
-    - the leading decoded character is not an opening '('
-    - the set operators do not match (&, |, or -)
-    - there is a trailing operator after the last querysting
+    - the individual querystrings are not wrapped in parentheses
+    - the set operators do not match the provided `operators`
+    - there is trailing content after the ending querysting
 
     Ex::
 
-        # unencoded query: (a=1) & (b=2) | (c=3) - (d=4)
-        >>> s = '%28a%253D1%29%26%28b%253D2%29%7C%28c%253D3%29-%28d%253D4%29'
+        # unencoded query: (a=1) & (b=2) | ~(c=3)
+        >>> s = '%28a%253D1%29%20%26%20%28b%253D2%29%20%7C%20%7E%28c%253D3%29'
         >>> decode_querystring_ops(s)
         [
-            ('a=1', '&'),
-            ('b=2', '|'),
-            ('c=3', '-'),
-            ('d=4', ''),
+            ('a=1', False, QuerySet.__and__),
+            ('b=2', False, QuerySet.__or__),
+            ('c=3', True, None),
         ]
     """
-    # decode into: (a%3D1)&(b%3D2)|(c%3D3)-(d%3D4)
+    complex_op_re = COMPLEX_OP_NEG_RE if negation else COMPLEX_OP_RE
+    if operators is None:
+        operators = COMPLEX_OPERATORS
+
+    # decode into: (a%3D1) & (b%3D2) | ~(c%3D3)
     decoded_querystring = unquote(encoded_querystring)
-    result = QUERYSTRING_OP_RE.findall(decoded_querystring)
+    matches = [m for m in complex_op_re.finditer(decoded_querystring)]
 
-    if not result:
-        raise ValidationError(
-            _("Unable to parse querystring. Decoded: '%(decoded)s'.") % {
-                'decoded': decoded_querystring
-            }
-        )
+    if not matches:
+        msg = _("Unable to parse querystring. Decoded: '%(decoded)s'.")
+        raise ValidationError(msg % {'decoded': decoded_querystring})
 
-    errors = []
-    for __, op in result[:-1]:
-        if op.strip() not in OPERATORS:
+    results, errors = [], []
+    for match, has_next in lookahead(matches):
+        negate, querystring, op = match.groups()
+
+        negate = negate == '~'
+        querystring = unquote(querystring)
+        op_func = operators.get(op.strip()) if op else None
+        if op_func is None and has_next:
             msg = _("Invalid querystring operator. Matched: '%(op)s'.")
             errors.append(msg % {'op': op})
 
-    if result[-1][1].strip() != '':
-        msg = _("Final querystring must not have an operator. Matched: '%(op)s'.")
-        errors.append(msg % {'op': result[-1][1]})
+        results.append(ComplexOp(querystring, negate, op_func))
+
+    trailing_chars = decoded_querystring[matches[-1].end():]
+    if trailing_chars:
+        msg = _("Ending querystring must not have trailing characters. Matched: '%(chars)s'.")
+        errors.append(msg % {'chars': trailing_chars})
 
     if errors:
         raise ValidationError(errors)
 
-    return [(unquote(querysting), op.strip()) for querysting, op in result]
+    return results

--- a/rest_framework_filters/utils.py
+++ b/rest_framework_filters/utils.py
@@ -62,3 +62,13 @@ def lookups_for_transform(transform):
             lookups.append(expr)
 
     return lookups
+
+
+def lookahead(iterable):
+    it = iter(iterable)
+    current = next(it)
+
+    for value in it:
+        yield current, True
+        current = value
+    yield current, False

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -132,6 +132,22 @@ class ComplexFilterBackendTests(APITestCase):
             'filters': ["Invalid querystring operator. Matched: 'asdf'."],
         })
 
+    def test_invalid_filterset_errors(self):
+        readable = '(id%3Dfoo) | (id%3Dbar)'
+        response = self.client.get('/ffcomplex-users/?filters=' + quote(readable), content_type='json')
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertDictEqual(response.data, {
+            'filters': {
+                'id=foo': {
+                    'id': ['Enter a number.'],
+                },
+                'id=bar': {
+                    'id': ['Enter a number.'],
+                },
+            },
+        })
+
     def test_pagination_compatibility(self):
         """
         Ensure that complex-filtering does not interfere with additional query param processing.

--- a/tests/test_complex_ops.py
+++ b/tests/test_complex_ops.py
@@ -1,9 +1,10 @@
 
 from urllib.parse import quote
 
+from django.db.models import QuerySet
 from django.test import TestCase
 from rest_framework.exceptions import ValidationError
-from rest_framework_filters.complex_ops import decode_querystring_ops
+from rest_framework_filters.complex_ops import decode_complex_ops
 
 
 def encode(querysting):
@@ -11,41 +12,40 @@ def encode(querysting):
         .replace('-', '%2D')
 
 
-class DecodeQuerystringOpsTests(TestCase):
+class DecodeComplexOpsTests(TestCase):
 
     def test_docstring(self):
-        encoded = '%28a%253D1%29%26%28b%253D2%29%7C%28c%253D3%29%2D%28d%253D4%29'
-        readable = '(a%3D1)&(b%3D2)|(c%3D3)-(d%3D4)'
+        encoded = '%28a%253D1%29%20%26%20%28b%253D2%29%20%7C%20%7E%28c%253D3%29'
+        readable = '(a%3D1) & (b%3D2) | ~(c%3D3)'
         result = [
-            ('a=1', '&'),
-            ('b=2', '|'),
-            ('c=3', '-'),
-            ('d=4', ''),
+            ('a=1', False, QuerySet.__and__),
+            ('b=2', False, QuerySet.__or__),
+            ('c=3', True, None),
         ]
 
         self.assertEqual(encode(readable), encoded)
-        self.assertEqual(decode_querystring_ops(encoded), result)
+        self.assertEqual(decode_complex_ops(encoded), result)
 
     def test_single_op(self):
         encoded = '%28a%253D1%29'
         readable = '(a%3D1)'
         result = [
-            ('a=1', ''),
+            ('a=1', False, None),
         ]
 
         self.assertEqual(encode(readable), encoded)
-        self.assertEqual(decode_querystring_ops(encoded), result)
+        self.assertEqual(decode_complex_ops(encoded), result)
 
     def test_op_spacing(self):
         encoded = '%28a%253D1%29%20%26%20%28b%253D2%29'
         readable = '(a%3D1) & (b%3D2)'
         result = [
-            ('a=1', '&'),
-            ('b=2', ''),
+            ('a=1', False, QuerySet.__and__),
+            ('b=2', False, None),
         ]
 
         self.assertEqual(encode(readable), encoded)
-        self.assertEqual(decode_querystring_ops(encoded), result)
+        self.assertEqual(decode_complex_ops(encoded), result)
 
     def test_missing_parens(self):
         encoded = 'a%253D1'
@@ -54,10 +54,23 @@ class DecodeQuerystringOpsTests(TestCase):
         self.assertEqual(encode(readable), encoded)
 
         with self.assertRaises(ValidationError) as exc:
-            decode_querystring_ops(encoded)
+            decode_complex_ops(encoded)
 
         self.assertEqual(exc.exception.detail, [
             "Unable to parse querystring. Decoded: 'a%3D1'.",
+        ])
+
+    def test_missing_closing_paren(self):
+        encoded = '%28a%253D1'
+        readable = '(a%3D1'
+
+        self.assertEqual(encode(readable), encoded)
+
+        with self.assertRaises(ValidationError) as exc:
+            decode_complex_ops(encoded)
+
+        self.assertEqual(exc.exception.detail, [
+            "Unable to parse querystring. Decoded: '(a%3D1'.",
         ])
 
     def test_missing_op(self):
@@ -67,7 +80,7 @@ class DecodeQuerystringOpsTests(TestCase):
         self.assertEqual(encode(readable), encoded)
 
         with self.assertRaises(ValidationError) as exc:
-            decode_querystring_ops(encoded)
+            decode_complex_ops(encoded)
 
         self.assertEqual(exc.exception.detail, [
             "Invalid querystring operator. Matched: ''."
@@ -80,10 +93,34 @@ class DecodeQuerystringOpsTests(TestCase):
         self.assertEqual(encode(readable), encoded)
 
         with self.assertRaises(ValidationError) as exc:
-            decode_querystring_ops(encoded)
+            decode_complex_ops(encoded)
 
         self.assertEqual(exc.exception.detail, [
             "Invalid querystring operator. Matched: 'asdf'.",
             "Invalid querystring operator. Matched: 'qwerty'.",
-            "Final querystring must not have an operator. Matched: '&'.",
+            "Ending querystring must not have trailing characters. Matched: '&'.",
+        ])
+
+    def test_negation(self):
+        encoded = '%28a%253D1%29%20%26%20%7E%28b%253D2%29'
+        readable = '(a%3D1) & ~(b%3D2)'
+        result = [
+            ('a=1', False, QuerySet.__and__),
+            ('b=2', True, None),
+        ]
+
+        self.assertEqual(encode(readable), encoded)
+        self.assertEqual(decode_complex_ops(encoded), result)
+
+    def test_duplicate_negation(self):
+        encoded = '%28a%253D1%29%20%26%20%7E%7E%28b%253D2%29'
+        readable = '(a%3D1) & ~~(b%3D2)'
+
+        self.assertEqual(encode(readable), encoded)
+
+        with self.assertRaises(ValidationError) as exc:
+            decode_complex_ops(encoded)
+
+        self.assertEqual(exc.exception.detail, [
+            "Invalid querystring operator. Matched: ' & ~'."
         ])

--- a/tests/test_complex_ops.py
+++ b/tests/test_complex_ops.py
@@ -1,0 +1,89 @@
+
+from urllib.parse import quote
+
+from django.test import TestCase
+from rest_framework.exceptions import ValidationError
+from rest_framework_filters.complex_ops import decode_querystring_ops
+
+
+def encode(querysting):
+    return quote(querysting) \
+        .replace('-', '%2D')
+
+
+class DecodeQuerystringOpsTests(TestCase):
+
+    def test_docstring(self):
+        encoded = '%28a%253D1%29%26%28b%253D2%29%7C%28c%253D3%29%2D%28d%253D4%29'
+        readable = '(a%3D1)&(b%3D2)|(c%3D3)-(d%3D4)'
+        result = [
+            ('a=1', '&'),
+            ('b=2', '|'),
+            ('c=3', '-'),
+            ('d=4', ''),
+        ]
+
+        self.assertEqual(encode(readable), encoded)
+        self.assertEqual(decode_querystring_ops(encoded), result)
+
+    def test_single_op(self):
+        encoded = '%28a%253D1%29'
+        readable = '(a%3D1)'
+        result = [
+            ('a=1', ''),
+        ]
+
+        self.assertEqual(encode(readable), encoded)
+        self.assertEqual(decode_querystring_ops(encoded), result)
+
+    def test_op_spacing(self):
+        encoded = '%28a%253D1%29%20%26%20%28b%253D2%29'
+        readable = '(a%3D1) & (b%3D2)'
+        result = [
+            ('a=1', '&'),
+            ('b=2', ''),
+        ]
+
+        self.assertEqual(encode(readable), encoded)
+        self.assertEqual(decode_querystring_ops(encoded), result)
+
+    def test_missing_parens(self):
+        encoded = 'a%253D1'
+        readable = 'a%3D1'
+
+        self.assertEqual(encode(readable), encoded)
+
+        with self.assertRaises(ValidationError) as exc:
+            decode_querystring_ops(encoded)
+
+        self.assertEqual(exc.exception.detail, [
+            "Unable to parse querystring. Decoded: 'a%3D1'.",
+        ])
+
+    def test_missing_op(self):
+        encoded = '%28a%253D1%29%28b%253D2%29%26%28c%253D3%29'
+        readable = '(a%3D1)(b%3D2)&(c%3D3)'
+
+        self.assertEqual(encode(readable), encoded)
+
+        with self.assertRaises(ValidationError) as exc:
+            decode_querystring_ops(encoded)
+
+        self.assertEqual(exc.exception.detail, [
+            "Invalid querystring operator. Matched: ''."
+        ])
+
+    def test_invalid_ops(self):
+        encoded = '%28a%253D1%29asdf%28b%253D2%29qwerty%28c%253D3%29%26'
+        readable = '(a%3D1)asdf(b%3D2)qwerty(c%3D3)&'
+
+        self.assertEqual(encode(readable), encoded)
+
+        with self.assertRaises(ValidationError) as exc:
+            decode_querystring_ops(encoded)
+
+        self.assertEqual(exc.exception.detail, [
+            "Invalid querystring operator. Matched: 'asdf'.",
+            "Invalid querystring operator. Matched: 'qwerty'.",
+            "Final querystring must not have an operator. Matched: '&'.",
+        ])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,3 +39,21 @@ class LookupsForTransformTests(TestCase):
 
         self.assertIn('unaccent__exact', lookups)
         self.assertNotIn('unaccent__unaccent__exact', lookups)
+
+
+class LookaheadTests(TestCase):
+    def test_empty(self):
+        result = list(utils.lookahead([]))
+        self.assertListEqual(result, [])
+
+    def test_single(self):
+        result = list(utils.lookahead([1]))
+        self.assertListEqual(result, [(1, False)])
+
+    def test_multiple(self):
+        result = list(utils.lookahead([1, 2, 3]))
+        self.assertListEqual(result, [
+            (1, True),
+            (2, True),
+            (3, False),
+        ])

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -8,6 +8,7 @@ from . import views
 router = routers.DefaultRouter()
 router.register(r'df-users', views.DFUserViewSet, base_name='df-users')
 router.register(r'ff-users', views.FilterFieldsUserViewSet, base_name='ff-users')
+router.register(r'ffcomplex-users', views.ComplexFilterFieldsUserViewSet, base_name='ffcomplex-users')
 router.register(r'users', views.UserViewSet,)
 router.register(r'notes', views.NoteViewSet,)
 

--- a/tests/testapp/views.py
+++ b/tests/testapp/views.py
@@ -29,6 +29,7 @@ class ComplexFilterFieldsUserViewSet(FilterFieldsUserViewSet):
     queryset = User.objects.order_by('pk')
     filter_backends = (backends.ComplexFilterBackend, )
     filter_fields = {
+        'id': '__all__',
         'username': '__all__',
         'email': '__all__',
     }

--- a/tests/testapp/views.py
+++ b/tests/testapp/views.py
@@ -1,5 +1,5 @@
 
-from rest_framework import viewsets
+from rest_framework import pagination, viewsets
 from rest_framework_filters import backends
 
 from .models import User, Note
@@ -32,6 +32,9 @@ class ComplexFilterFieldsUserViewSet(FilterFieldsUserViewSet):
         'username': '__all__',
         'email': '__all__',
     }
+
+    class pagination_class(pagination.PageNumberPagination):
+        page_size_query_param = 'page_size'
 
 
 class UserViewSet(viewsets.ModelViewSet):

--- a/tests/testapp/views.py
+++ b/tests/testapp/views.py
@@ -25,6 +25,15 @@ class FilterFieldsUserViewSet(viewsets.ModelViewSet):
     }
 
 
+class ComplexFilterFieldsUserViewSet(FilterFieldsUserViewSet):
+    queryset = User.objects.order_by('pk')
+    filter_backends = (backends.ComplexFilterBackend, )
+    filter_fields = {
+        'username': '__all__',
+        'email': '__all__',
+    }
+
+
 class UserViewSet(viewsets.ModelViewSet):
     queryset = User.objects.all()
     serializer_class = UserSerializer


### PR DESCRIPTION
This is a first pass at #54, which should enable filtering the UNION, INTERSECTION, and DIFFERENCE of multiple invocations of the same filteset. For example, let's say you want to filter for users whose `first_name=bob` or `last_name=jones`. The desired query is something like:

```python
q1 = User.objects.filter(first_name='bob')
q2 = User.objects.filter(last_name='jones')

return q1.union(q2)
```

The above is not currently possible, without creating a custom `Filter.method`. Even with a custom `method`, this solution is not flexible and does not easily allow for arbitrary queries. 

Ultimately, the problem is at a higher order than the individual filterset, which is focused on producing a *single* query. The solution is to perform set operations on the results of *multiple* filterset queries. eg, 

```python
q1 = UserFilter({'first_name': 'bob'}).qs
q2 = UserFilter({'last_name': 'jones'}).qs

return q1.union(q2)
```

However, the problem is that querystrings only represent a *single* set of `key=value` pairs. This PR circumvents this by providing a custom `MultiFilterBackend` that expects the various groups of query params to be encoded as a single value in the querysting. The basic procedure for the client is to encode the sets of params, wrap those in parentheses, apply the set operations to the groups, then encode the overall result and assign to an actual query param name. The encoding steps should look something like:
- `(first_name=bob) | (last_name=jones)`
- `(first_name%3Dbob) | (last_name%3Djones)`
- `%28first_name%253Dbob%29%20%7C%20%28last_name%253Djones%29`
- `filters=%28first_name%253Dbob%29%20%7C%20%28last_name%253Djones%29`