### PR TITLE
Rework related filtering

### DIFF
--- a/rest_framework_filters/backends.py
+++ b/rest_framework_filters/backends.py
@@ -21,8 +21,8 @@ class RestFrameworkFilterBackend(backends.DjangoFilterBackend):
     @contextmanager
     def patch_for_rendering(self, request):
         """
-        Patch `get_filterset_class()` so the resulting filterset does not perform
-        filter expansion during form rendering.
+        Patch `.get_filterset_class()` so the resulting filterset does not
+        perform filter expansion during form rendering.
         """
         original = self.get_filterset_class
 
@@ -31,7 +31,7 @@ class RestFrameworkFilterBackend(backends.DjangoFilterBackend):
 
             # django-filter compatibility
             if issubclass(filterset_class, FilterSet):
-                filterset_class = filterset_class.disable_subset()
+                filterset_class = filterset_class.disable_subset(depth=1)
 
             return filterset_class
 
@@ -42,8 +42,8 @@ class RestFrameworkFilterBackend(backends.DjangoFilterBackend):
             self.get_filterset_class = original
 
     def to_html(self, request, queryset, view):
-        # patching the behavior of `get_filterset_class()` in this method allows
-        # us to avoid maintenance issues with code duplication.
+        # Patching the behavior of `.get_filterset_class()` in this method
+        # allows us to avoid maintenance issues with code duplication.
         with self.patch_for_rendering(request):
             return super().to_html(request, queryset, view)
 

--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -2,11 +2,21 @@ import copy
 from collections import OrderedDict
 from contextlib import contextmanager
 
+from django.db.models import Subquery
 from django.db.models.constants import LOOKUP_SEP
 from django_filters import filterset, rest_framework
 from django_filters.utils import get_model_field
 
 from . import filters, utils
+
+
+def related(filterset, filter_name):
+    """
+    Return a related filter_name, using the filterset relationship if present.
+    """
+    if not filterset.relationship:
+        return filter_name
+    return LOOKUP_SEP.join([filterset.relationship, filter_name])
 
 
 class FilterSetMetaclass(filterset.FilterSetMetaclass):
@@ -85,6 +95,7 @@ class FilterSet(rest_framework.FilterSet, metaclass=FilterSetMetaclass):
         super().__init__(data, queryset, **kwargs)
 
         self.relationship = relationship
+        self.related_filtersets = self.get_related_filtersets()
         self.request_filters = self.get_request_filters()
 
     @classmethod
@@ -177,34 +188,20 @@ class FilterSet(rest_framework.FilterSet, metaclass=FilterSetMetaclass):
 
     def get_request_filters(self):
         """
-        Build a set of filters based on the request data. The resulting set
-        will walk `RelatedFilter`s to recursively build the set of filters.
+        Build a set of filters based on the request data. This currently
+        includes only filter exclusion/negation.
         """
-        # build param data for related filters: {rel: {param: value}}
-        related_data = OrderedDict(
-            [(name, OrderedDict()) for name in self.__class__.related_filters]
-        )
-        for param, value in self.data.items():
-            filter_name, related_param = self.get_related_filter_param(param)
-
-            # skip non lookup/related keys
-            if filter_name is None:
-                continue
-
-            if filter_name in related_data:
-                related_data[filter_name][related_param] = value
-
         # build the compiled set of all filters
         requested_filters = OrderedDict()
         for filter_name, f in self.filters.items():
             exclude_name = '%s!' % filter_name
 
             # Add plain lookup filters if match. ie, `username__icontains`
-            if filter_name in self.data:
+            if related(self, filter_name) in self.data:
                 requested_filters[filter_name] = f
 
             # include exclusion keys
-            if exclude_name in self.data:
+            if related(self, exclude_name) in self.data:
                 # deepcopy the *base* filter to prevent copying of model & parent
                 f_copy = copy.deepcopy(self.base_filters[filter_name])
                 f_copy.parent = f.parent
@@ -213,44 +210,28 @@ class FilterSet(rest_framework.FilterSet, metaclass=FilterSetMetaclass):
 
                 requested_filters[exclude_name] = f_copy
 
-            # include filters from related subsets
-            if isinstance(f, filters.RelatedFilter) and filter_name in related_data:
-                subset_data = related_data[filter_name]
-                filterset = f.filterset(data=subset_data, request=self.request)
-
-                # modify filter names to account for relationship
-                for related_name, related_f in filterset.get_request_filters().items():
-                    related_name = LOOKUP_SEP.join([filter_name, related_name])
-                    related_f.field_name = LOOKUP_SEP.join([f.field_name, related_f.field_name])
-                    requested_filters[related_name] = related_f
-
         return requested_filters
 
-    @classmethod
-    def get_related_filter_param(cls, param):
+    def get_related_filtersets(self):
         """
-        Get a tuple of (filter name, related param).
-
-        ex::
-
-            >>> FilterSet.get_related_filter_param('author__email__foobar')
-            ('author', 'email__foobar')
-
-            >>> FilterSet.get_related_filter_param('author')
-            (None, None)
-
+        Get the related filterset instances for all related filters.
         """
-        # preference more specific filters. eg, `note__author` over `note`.
-        for name in reversed(sorted(cls.related_filters)):
-            # we need to match against '__' to prevent eager matching against
-            # like names. eg, note vs note2. Exact matches are handled above.
-            if param.startswith("%s%s" % (name, LOOKUP_SEP)):
-                # strip param + LOOKUP_SET from param
-                related_param = param[len(name) + len(LOOKUP_SEP):]
-                return name, related_param
+        related_filtersets = OrderedDict()
 
-        # not a related param
-        return None, None
+        for related_name in self.related_filters:
+            if related_name not in self.filters:
+                continue
+
+            f = self.filters[related_name]
+            related_filtersets[related_name] = f.filterset(
+                data=self.data,
+                queryset=f.get_queryset(self.request),
+                relationship=related(self, related_name),
+                request=self.request,
+                prefix=self.form_prefix,
+            )
+
+        return related_filtersets
 
     @contextmanager
     def override_filters(self):
@@ -264,7 +245,28 @@ class FilterSet(rest_framework.FilterSet, metaclass=FilterSetMetaclass):
 
     def filter_queryset(self, queryset):
         with self.override_filters():
-            return super(FilterSet, self).filter_queryset(queryset)
+            queryset = super(FilterSet, self).filter_queryset(queryset)
+            queryset = self.filter_related_filtersets(queryset)
+            return queryset
+
+    def filter_related_filtersets(self, queryset):
+        """
+        Filter the provided `queryset` by the `related_filtersets`. It is
+        recommended that you override this method to change the filtering
+        behavior across relationships.
+        """
+        for related_name, related_filterset in self.related_filtersets.items():
+            # Related filtersets should only be applied if they had data.
+            prefix = '%s%s' % (related(self, related_name), LOOKUP_SEP)
+            if not any(value.startswith(prefix) for value in self.data):
+                continue
+
+            field_name = self.related_filters[related_name].field_name
+            lookup_expr = LOOKUP_SEP.join([field_name, 'in'])
+            subquery = Subquery(related_filterset.qs.values('pk'))
+            queryset = queryset.filter(**{lookup_expr: subquery})
+
+        return queryset
 
     def get_form_class(self):
         with self.override_filters():

--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -273,7 +273,7 @@ class FilterSet(rest_framework.FilterSet, metaclass=FilterSetMetaclass):
             if not any(value.startswith(prefix) for value in self.data):
                 continue
 
-            field_name = self.related_filters[related_name].field_name
+            field_name = self.filters[related_name].field_name
             lookup_expr = LOOKUP_SEP.join([field_name, 'in'])
             subquery = Subquery(related_filterset.qs.values('pk'))
             queryset = queryset.filter(**{lookup_expr: subquery})

--- a/rest_framework_filters/templates/rest_framework_filters/crispy_form.html
+++ b/rest_framework_filters/templates/rest_framework_filters/crispy_form.html
@@ -1,5 +1,16 @@
+{% load rest_framework_filters %}
 {% load crispy_forms_tags %}
 {% load i18n %}
 
 <h2>{% trans "Field filters" %}</h2>
 {% crispy filter.form %}
+
+{% for related_name, filterset in filter.related_filtersets.items %}
+<fieldset>
+    <legend>{{ filter|label:related_name }}</legend>
+
+    {% comment %}
+    {% crispy filterset.form %}
+    {% endcomment %}
+</fieldset>
+{% endfor %}

--- a/rest_framework_filters/templates/rest_framework_filters/form.html
+++ b/rest_framework_filters/templates/rest_framework_filters/form.html
@@ -1,6 +1,17 @@
+{% load rest_framework_filters %}
 {% load i18n %}
+
 <h2>{% trans "Field filters" %}</h2>
 <form class="form" action="" method="get">
     {{ filter.form.as_p }}
+
+    {% for related_name, filterset in filter.related_filtersets.items %}
+    <fieldset>
+        <legend>{{ filter|label:related_name }}</legend>
+
+        {{ filterset.form.as_p }}
+    </fieldset>
+    {% endfor %}
+
     <button type="submit" class="btn btn-primary">{% trans "Submit" %}</button>
 </form>

--- a/rest_framework_filters/templatetags/rest_framework_filters.py
+++ b/rest_framework_filters/templatetags/rest_framework_filters.py
@@ -1,0 +1,10 @@
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def label(filterset, relationship):
+    f = filterset
+    f = f.filters[relationship]
+    return f.label

--- a/tests/related/test_exclude.py
+++ b/tests/related/test_exclude.py
@@ -1,5 +1,3 @@
-import unittest
-
 from django.test import TestCase
 
 from tests.testapp.filters import BlogFilter
@@ -109,7 +107,6 @@ class ExcludeTests(RelationshipData, TestCase):
         self.verify(q5, self.NOT_CORRECT_ONE)
 
     # Test behavior
-    @unittest.expectedFailure
     def test_reverse_fk(self):
         GET = {
             'post__title__contains!': 'Lennon',

--- a/tests/related/test_filter.py
+++ b/tests/related/test_filter.py
@@ -1,5 +1,3 @@
-import unittest
-
 from django.test import TestCase
 
 from tests.testapp.filters import BlogFilter
@@ -77,7 +75,6 @@ class FilterTests(RelationshipData, TestCase):
         self.verify(q3, self.CORRECT)
 
     # Test behavior
-    @unittest.expectedFailure
     def test_reverse_fk(self):
         GET = {
             'post__title__contains': 'Lennon',

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -309,8 +309,8 @@ class RelatedFilterTests(TestCase):
         class ChildFilter(PostFilter):
             foo = filters.RelatedFilter(PostFilter)
 
-        self.assertEqual(['note', 'tags'], list(PostFilter.related_filters))
-        self.assertEqual(['note', 'tags', 'foo'], list(ChildFilter.related_filters))
+        self.assertEqual(['author', 'note', 'tags'], list(PostFilter.related_filters))
+        self.assertEqual(['author', 'note', 'tags', 'foo'], list(ChildFilter.related_filters))
 
     def test_relatedfilter_queryset_required(self):
         # Use a secure default queryset. Previous behavior was to use the default model

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1,5 +1,3 @@
-import unittest
-
 from django.test import TestCase
 from django_filters import FilterSet as DFFilterSet
 
@@ -326,12 +324,10 @@ class RelatedFilterTests(TestCase):
                 fields = []
 
         GET = {'author': User.objects.get(username='user2').pk}
-        f = NoteFilter(GET, queryset=Note.objects.all())
-
         msg = "Expected `.get_queryset()` for related filter 'NoteFilter.author' " \
               "to return a `QuerySet`, but got `None`."
         with self.assertRaisesMessage(AssertionError, msg):
-            f.qs
+            NoteFilter(GET, queryset=Note.objects.all())
 
     def test_relatedfilter_request_is_passed(self):
         called = False
@@ -409,7 +405,6 @@ class AnnotationTests(TestCase):
 
         self.assertEqual([p.content for p in f.qs], ['Post 1'])
 
-    @unittest.expectedFailure
     def test_related_annotation(self):
         f = UserFilter(
             {'posts__is_published': 'true'},

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -213,6 +213,10 @@ class GetParamFilterNameTests(TestCase):
         name = NoteFilter.get_param_filter_name('author__foobar')
         self.assertEqual('author', name)
 
+    def test_relationship_regular_filter(self):
+        name = UserFilter.get_param_filter_name('author__email', rel='author')
+        self.assertEqual('email', name)
+
     def test_twice_removed_related_filter(self):
         class PostFilterWithDirectAuthor(PostFilter):
             note__author = filters.RelatedFilter(UserFilter)

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -504,9 +504,8 @@ class FilterExclusionTests(TestCase):
         }
 
         filterset = TagFilter(GET, queryset=Tag.objects.all())
-        requested_filters = filterset.request_filters
 
-        self.assertTrue(requested_filters['name__contains!'].exclude)
+        self.assertTrue(filterset.filters['name__contains!'].exclude)
 
     def test_filter_and_exclude(self):
         """
@@ -518,10 +517,9 @@ class FilterExclusionTests(TestCase):
         }
 
         filterset = TagFilter(GET, queryset=Tag.objects.all())
-        requested_filters = filterset.request_filters
 
-        self.assertFalse(requested_filters['name__contains'].exclude)
-        self.assertTrue(requested_filters['name__contains!'].exclude)
+        self.assertFalse(filterset.filters['name__contains'].exclude)
+        self.assertTrue(filterset.filters['name__contains!'].exclude)
 
     def test_related_exclude(self):
         GET = {
@@ -529,9 +527,9 @@ class FilterExclusionTests(TestCase):
         }
 
         filterset = PostFilter(GET, queryset=Post.objects.all())
-        requested_filters = filterset.request_filters
+        filterset = filterset.related_filtersets['tags']
 
-        self.assertTrue(requested_filters['tags__name__contains!'].exclude)
+        self.assertTrue(filterset.filters['name__contains!'].exclude)
 
     def test_exclusion_results(self):
         GET = {

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -481,28 +481,6 @@ class DisableSubsetRecursiveTests(TestCase):
         self.assertTrue(issubclass(original, F))
 
 
-class OverrideFiltersTests(TestCase):
-
-    def test_bound(self):
-        f = PostFilter({})
-
-        with f.override_filters():
-            self.assertEqual(len(f.filters), 0)
-
-    def test_not_bound(self):
-        f = PostFilter(None)
-
-        with f.override_filters():
-            self.assertEqual(len(f.filters), 0)
-
-    def test_subset_disabled(self):
-        f = PostFilter.disable_subset()(None)
-
-        with f.override_filters():
-            # The number of filters varies by Django version
-            self.assertGreater(len(f.filters), 30)
-
-
 class FilterExclusionTests(TestCase):
 
     @classmethod

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,0 +1,83 @@
+from django import forms
+from django.test import TestCase
+
+from rest_framework_filters import FilterSet, filters
+
+from .testapp.filters import PostFilter
+from .testapp.models import Post, User
+
+
+class FilterSetFormTests(TestCase):
+
+    def test_form_inheritance(self):
+        class MyForm(forms.Form):
+            pass
+
+        class F(FilterSet):
+            class Meta:
+                model = Post
+                fields = []
+                form = MyForm
+
+        self.assertIsInstance(F().form, MyForm)
+
+    def test_subset_disabled_form_fields(self):
+        # Form fields should reliably display when the subset is disabled
+        class F(FilterSet):
+            class Meta:
+                model = Post
+                fields = ['title', 'content']
+
+        F = F.disable_subset()
+        form = F({}).form
+        self.assertEqual(list(form.fields), ['title', 'content'])
+
+    def test_unbound_form_fields(self):
+        class F(FilterSet):
+            class Meta:
+                model = Post
+                fields = ['title', 'content']
+
+        form = F().form
+        self.assertEqual(list(form.fields), [])
+
+    def test_bound_form_fields(self):
+        class F(FilterSet):
+            class Meta:
+                model = Post
+                fields = ['title', 'content']
+
+        form = F({}).form
+        self.assertEqual(list(form.fields), [])
+
+        form = F({'title': 'foo'}).form
+        self.assertEqual(list(form.fields), ['title'])
+
+    def test_related_form_fields(self):
+        # FilterSet form should not contain fields from related filtersets
+
+        class F(FilterSet):
+            author = filters.RelatedFilter(
+                'tests.testapp.filters.UserFilter',
+                queryset=User.objects.all(),
+            )
+
+            class Meta:
+                model = Post
+                fields = ['title', 'author']
+
+        form = F({'title': '', 'author': '', 'author__email': ''}).form
+        self.assertEqual(list(form.fields), ['title', 'author'])
+
+        form = F({'title': '', 'author': '', 'author__email': ''}).related_filtersets['author'].form
+        self.assertEqual(list(form.fields), ['email'])
+
+    def test_validation_errors(self):
+        f = PostFilter({
+            'publish_date__year': 'foo',
+            'author__last_login__date': 'bar',
+        })
+        self.assertEqual(f.form.errors, {
+            'publish_date__year': ['Enter a number.'],
+            'author__last_login__date': ['Enter a valid date.'],
+        })

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -7,7 +7,6 @@ that the FilterSet continue to behave as expected.
 """
 
 import datetime
-import unittest
 
 from django.test import TestCase, override_settings
 from django.utils.dateparse import parse_datetime, parse_time
@@ -331,7 +330,6 @@ class FilterMethodTests(TestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].content, "Test content in post 2")
 
-    @unittest.expectedFailure
     def test_related_method_filter(self):
         """
         Missing MethodFilter filter methods are silently ignored, returning

--- a/tests/testapp/filters.py
+++ b/tests/testapp/filters.py
@@ -142,7 +142,7 @@ class AFilter(FilterSet):
 
 
 class BFilter(FilterSet):
-    name = AutoFilter(field_name='name', lookups='__all__')
+    name = filters.CharFilter(field_name='name')
     c = RelatedFilter('CFilter', field_name='c', queryset=C.objects.all())
 
     class Meta:

--- a/tests/testapp/filters.py
+++ b/tests/testapp/filters.py
@@ -62,6 +62,7 @@ class PostFilter(FilterSet):
     publish_date = filters.AutoFilter(lookups='__all__')
     is_published = filters.BooleanFilter(method='filter_is_published')
 
+    author = RelatedFilter(UserFilter, field_name='author', queryset=User.objects.all())
     note = RelatedFilter(NoteFilter, field_name='note', queryset=Note.objects.all())
     tags = RelatedFilter(TagFilter, field_name='tags', queryset=Tag.objects.all())
 


### PR DESCRIPTION
Alternative implementation to #197. This also needs further testing, but in general I'm happier with it.

The major difference is how data is passed between filtersets. In the current implementation (and #197), related filtersets are provided with a transformed data dictionary where their relationship name has been stripped from the data keys. The downside to #197 is that it's not possible to render related filterset forms. 

In contrast, this approach passes the same incoming data to its related filtersets, untransformed. As a result, users should have a way to render related filterset forms with no conflict.

Overall, here is what this PR would enable:
- Correct behavior when filtering across to-many relationships ([ref](https://docs.djangoproject.com/en/1.11/topics/db/queries/#spanning-multi-valued-relationships)).
- Related Filters can now enforce queryset/choices restrictions. (eg, only display choices for related articles that have been published or are authored by the request user).
- No longer necessary to customize method filters (previously requires munging the `field_name`).
- Filtering against *related* annotations. Previously this was not possible, as the related filters were applied to the root queryset, and not the nested/related queryset. 

**Changes:**
- Add `FilterSet.relationship`, which allows the filterset to parse it's params across relationships. ~~This is compatible with `form_prefix`, although that's not usually relevant with API filtersets.~~ It turns out, form prefixes aren't directly compatible, as the subsetting happens before parent initialization/filter deepcopy'ing, and prefix/relationship detection only occurs after. This *could* be supported, but it doesn't seem worth the trouble. i.e., we don't need prefixes to support rendering related filtersets.
- Add the `FilterSet.get_related_filtersets()` method and it's corresponding `FilterSet.related_filtersets` attribute. The latter is simply the cached result of the former. This method constructs a dict of related filtersets, keyed by their relationship name.
- Add the `FilterSet.filter_related_filtersets()` method, which is a hook for defining the behavior of how related filtersets are filtered. 
- Add templates that display the first level of related filtersets.

**TODO:**
- [x] Test `FilterSet.get_related_filtersets()`
- [x] ~~Test `FilterSet.filter_related_filtersets()`~~ Implicit through existing tests
- [x] Test templates (test post data)
- [x] Test related filterset errors
- [x] Ensure there are no tests marked as expected failures
