### PR TITLE
Use tox-venv for py3 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - "3.6"
 
 install:
-  - travis_retry pip install detox tox-travis coverage
+  - travis_retry pip install detox tox-travis tox-venv coverage
 script:
   - detox -- -v 2
 after_success:


### PR DESCRIPTION
In short, the warnings build is failing due to issues with `virtualenv`. `tox-venv` uses the builtin python 3 `venv` module to build python 3 test envs instead, bypassing `virtualenv`'s issues.