### PR TITLE
Rename backend, use separate template paths

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include README.rst
+recursive-include rest_framework_filters/templates *.html
+global-exclude __pycache__
+global-exclude *.py[co]

--- a/README.rst
+++ b/README.rst
@@ -59,9 +59,21 @@ Requirements
 Installation
 ------------
 
+Install with pip, or your preferred package manager:
+
 .. code-block:: bash
 
     $ pip install djangorestframework-filters
+
+
+Add to your ``INSTALLED_APPS`` setting:
+
+.. code-block:: python
+
+    INSTALLED_APPS = [
+        'rest_framework_filters',
+        ...
+    ]
 
 
 ``FilterSet`` usage
@@ -96,7 +108,7 @@ To use the django-rest-framework-filters backend, add the following to your sett
 
     REST_FRAMEWORK = {
         'DEFAULT_FILTER_BACKENDS': (
-            'rest_framework_filters.backends.DjangoFilterBackend', ...
+            'rest_framework_filters.backends.RestFrameworkFilterBackend', ...
         ),
         ...
 
@@ -457,7 +469,7 @@ By default, the backend combines queries with both ``&`` (AND) and ``|`` (OR), a
 
 The backend supports both standard and complex queries. To perform complex queries, the query must be encoded and set
 as the value of the ``complex_filter_param`` (defaults to ``filters``). To perform standard queries, use the backend
-in the same manner as the ``DjangoFilterBackend``.
+in the same manner as the ``RestFrameworkFilterBackend``.
 
 
 Configuring ``ComplexFilterBackend``
@@ -553,6 +565,14 @@ errors would be raised like so:
 
 Migrating to 1.0
 ----------------
+
+Backend renamed, provides new templates
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The backend has been renamed from ``DjangoFilterBackend`` to ``RestFrameworkFilterBackend`` and now uses its own
+template paths, located under ``rest_framework_filters`` instead of ``django_filters/rest_framework``.
+
+To load the included templates, it is necessary to add ``rest_framework_filters`` to the ``INSTALLED_APPS`` setting.
 
 ``RelatedFilter.queryset`` now required
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/rest_framework_filters/backends.py
+++ b/rest_framework_filters/backends.py
@@ -13,7 +13,7 @@ def noop(self):
     yield
 
 
-class DjangoFilterBackend(backends.DjangoFilterBackend):
+class RestFrameworkFilterBackend(backends.DjangoFilterBackend):
     default_filter_set = FilterSet
 
     @contextmanager
@@ -38,10 +38,10 @@ class DjangoFilterBackend(backends.DjangoFilterBackend):
         # patching the behavior of `get_filter_class()` in this method allows
         # us to avoid maintenance issues with code duplication.
         with self.patch_for_rendering(request):
-            return super(DjangoFilterBackend, self).to_html(request, queryset, view)
+            return super(RestFrameworkFilterBackend, self).to_html(request, queryset, view)
 
 
-class ComplexFilterBackend(DjangoFilterBackend):
+class ComplexFilterBackend(RestFrameworkFilterBackend):
     complex_filter_param = 'filters'
     operators = None
     negation = True

--- a/rest_framework_filters/backends.py
+++ b/rest_framework_filters/backends.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 
 from django.http import QueryDict
+from django_filters import compat
 from django_filters.rest_framework import backends
 from rest_framework.exceptions import ValidationError
 
@@ -15,6 +16,12 @@ def noop(self):
 
 class RestFrameworkFilterBackend(backends.DjangoFilterBackend):
     default_filter_set = FilterSet
+
+    @property
+    def template(self):
+        if compat.is_crispy():
+            return 'rest_framework_filters/crispy_form.html'
+        return 'rest_framework_filters/form.html'
 
     @contextmanager
     def patch_for_rendering(self, request):

--- a/rest_framework_filters/templates/rest_framework_filters/crispy_form.html
+++ b/rest_framework_filters/templates/rest_framework_filters/crispy_form.html
@@ -1,0 +1,5 @@
+{% load crispy_forms_tags %}
+{% load i18n %}
+
+<h2>{% trans "Field filters" %}</h2>
+{% crispy filter.form %}

--- a/rest_framework_filters/templates/rest_framework_filters/form.html
+++ b/rest_framework_filters/templates/rest_framework_filters/form.html
@@ -1,0 +1,6 @@
+{% load i18n %}
+<h2>{% trans "Field filters" %}</h2>
+<form class="form" action="" method="get">
+    {{ filter.form.as_p }}
+    <button type="submit" class="btn btn-primary">{% trans "Submit" %}</button>
+</form>

--- a/setup.py
+++ b/setup.py
@@ -1,37 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from setuptools import setup
-import os
+from setuptools import setup, find_packages
 
 
 with open('README.rst') as f:
     README = f.read()
-
-
-def get_packages(package):
-    """
-    Return root package and all sub-packages.
-    """
-    return [dirpath
-            for dirpath, dirnames, filenames in os.walk(package)
-            if os.path.exists(os.path.join(dirpath, '__init__.py'))]
-
-
-def get_package_data(package):
-    """
-    Return all files under the root package, that are not in a
-    package themselves.
-    """
-    walk = [(dirpath.replace(package + os.sep, '', 1), filenames)
-            for dirpath, dirnames, filenames in os.walk(package)
-            if not os.path.exists(os.path.join(dirpath, '__init__.py'))]
-
-    filepaths = []
-    for base, filenames in walk:
-        filepaths.extend([os.path.join(base, filename)
-                          for filename in filenames])
-    return {package: filepaths}
 
 
 setup(
@@ -43,8 +17,8 @@ setup(
     description='Better filtering for Django REST Framework',
     author='Philip Neustrom',
     author_email='philipn@gmail.com',
-    packages=get_packages('rest_framework_filters'),
-    package_data=get_package_data('rest_framework_filters'),
+    packages=find_packages(exclude=['tests*']),
+    include_package_data=True,
     zip_safe=False,
     install_requires=[
         'djangorestframework',

--- a/tests/perf/views.py
+++ b/tests/perf/views.py
@@ -18,5 +18,5 @@ class DFNoteViewSet(viewsets.ModelViewSet):
 class DRFFNoteViewSet(viewsets.ModelViewSet):
     queryset = Note.objects.all()
     serializer_class = NoteSerializer
-    filter_backends = (drf_backends.DjangoFilterBackend, )
+    filter_backends = (drf_backends.RestFrameworkFilterBackend, )
     filter_class = NoteFilterWithRelatedAll

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -18,6 +18,7 @@ INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.staticfiles',
+    'rest_framework_filters',
     'rest_framework',
     'django_filters',
     'tests.testapp',

--- a/tests/testapp/views.py
+++ b/tests/testapp/views.py
@@ -13,14 +13,14 @@ class DFUserViewSet(viewsets.ModelViewSet):
     # with standard django-filter FilterSets.
     queryset = User.objects.all()
     serializer_class = UserSerializer
-    filter_backends = (backends.DjangoFilterBackend, )
+    filter_backends = (backends.RestFrameworkFilterBackend, )
     filter_class = DFUserFilter
 
 
 class FilterFieldsUserViewSet(viewsets.ModelViewSet):
     queryset = User.objects.all()
     serializer_class = UserSerializer
-    filter_backends = (backends.DjangoFilterBackend, )
+    filter_backends = (backends.RestFrameworkFilterBackend, )
     filter_fields = {
         'username': '__all__',
     }
@@ -42,12 +42,12 @@ class ComplexFilterFieldsUserViewSet(FilterFieldsUserViewSet):
 class UserViewSet(viewsets.ModelViewSet):
     queryset = User.objects.all()
     serializer_class = UserSerializer
-    filter_backends = (backends.DjangoFilterBackend, )
+    filter_backends = (backends.RestFrameworkFilterBackend, )
     filter_class = UserFilterWithAll
 
 
 class NoteViewSet(viewsets.ModelViewSet):
     queryset = Note.objects.all()
     serializer_class = NoteSerializer
-    filter_backends = (backends.DjangoFilterBackend, )
+    filter_backends = (backends.RestFrameworkFilterBackend, )
     filter_class = NoteFilterWithRelatedAll

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     ; Test two versions of DRF against Django's LTS
     py{34,35,36}-django{111}-restframework{36,37},
     py{34,35,36}-django{20}-restframework{37},
-    performance, warnings,
+    performance, warnings, lint, dist
 
 [travis]
 unignore_outcomes = true


### PR DESCRIPTION
The goal is to further separate/distinguish the drf-filters and django-filter backends.
- Rename backend class to `RestFrameworkFilterBackend` (was `DjangoFilterBackend`).
- Locate templates under `rest_framework_filters` directory (was `django_filters/rest_framework`).

Also fixed up a few packaging/CI issues