### PR TITLE
Simplify test filters

### DIFF
--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -6,8 +6,8 @@ from rest_framework_filters import FilterSet, filters
 from .testapp.filters import (
     CFilter, CoverFilter, NoteFilterWithAll, NoteFilterWithRelated,
     NoteFilterWithRelatedAll, NoteFilterWithRelatedAllDifferentFilterName,
-    NoteFilterWithRelatedDifferentName, PageFilterWithAliasedNestedRelated,
-    PersonFilter, PostFilter, UserFilter,
+    NoteFilterWithRelatedDifferentName, PageFilter, PersonFilter, PostFilter,
+    UserFilter,
 )
 from .testapp.models import A, B, C, Cover, Note, Page, Person, Post, Tag, User
 
@@ -207,10 +207,10 @@ class RelatedFilterTests(TestCase):
     def test_relatedfilter_for_aliased_nested_relationships(self):
         qs = Page.objects.order_by('pk')
 
-        f1 = PageFilterWithAliasedNestedRelated({'two_pages_back': '1'}, queryset=qs)
-        f2 = PageFilterWithAliasedNestedRelated({'two_pages_back': '2'}, queryset=qs)
-        f3 = PageFilterWithAliasedNestedRelated({'two_pages_back': '3'}, queryset=qs)
-        f4 = PageFilterWithAliasedNestedRelated({'two_pages_back': '4'}, queryset=qs)
+        f1 = PageFilter({'two_pages_back': '1'}, queryset=qs)
+        f2 = PageFilter({'two_pages_back': '2'}, queryset=qs)
+        f3 = PageFilter({'two_pages_back': '3'}, queryset=qs)
+        f4 = PageFilter({'two_pages_back': '4'}, queryset=qs)
 
         self.assertQuerysetEqual(f1.qs, [3], lambda p: p.pk)
         self.assertQuerysetEqual(f2.qs, [4], lambda p: p.pk)

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -5,9 +5,8 @@ from rest_framework_filters import FilterSet, filters
 
 from .testapp.filters import (
     CFilter, CoverFilter, NoteFilterWithAll, NoteFilterWithRelated,
-    NoteFilterWithRelatedAll, NoteFilterWithRelatedAllDifferentFilterName,
-    NoteFilterWithRelatedDifferentName, PageFilter, PersonFilter, PostFilter,
-    UserFilter,
+    NoteFilterWithRelatedAll, NoteFilterWithAlias, NoteFilterWithRelatedAlias,
+    PageFilter, PersonFilter, PostFilter, UserFilter,
 )
 from .testapp.models import A, B, C, Cover, Note, Page, Person, Post, Tag, User
 
@@ -180,28 +179,28 @@ class RelatedFilterTests(TestCase):
         GET = {
             'writer': User.objects.get(username='user2').pk,
         }
-        f = NoteFilterWithRelatedAllDifferentFilterName(GET, queryset=Note.objects.all())
+        f = NoteFilterWithAlias(GET, queryset=Note.objects.all())
         self.assertEqual(len(list(f.qs)), 1)
         note = list(f.qs)[0]
         self.assertEqual(note.title, "Hello Test 4")
 
         # Test the username filter on the related UserFilter set.
         GET = {'writer__username': 'user2'}
-        f = NoteFilterWithRelatedAllDifferentFilterName(GET, queryset=Note.objects.all())
+        f = NoteFilterWithAlias(GET, queryset=Note.objects.all())
         self.assertEqual(len(list(f.qs)), 1)
         self.assertEqual(list(f.qs)[0].title, "Hello Test 4")
 
         GET = {'writer__username__endswith': '2'}
-        f = NoteFilterWithRelatedAllDifferentFilterName(GET, queryset=Note.objects.all())
+        f = NoteFilterWithAlias(GET, queryset=Note.objects.all())
         self.assertEqual(len(list(f.qs)), 1)
         self.assertEqual(list(f.qs)[0].title, "Hello Test 4")
 
         GET = {'writer__username__endswith': '1'}
-        f = NoteFilterWithRelatedAllDifferentFilterName(GET, queryset=Note.objects.all())
+        f = NoteFilterWithAlias(GET, queryset=Note.objects.all())
         self.assertEqual(len(list(f.qs)), 3)
 
         GET = {'writer__username__contains': 'user'}
-        f = NoteFilterWithRelatedAllDifferentFilterName(GET, queryset=Note.objects.all())
+        f = NoteFilterWithAlias(GET, queryset=Note.objects.all())
         self.assertEqual(len(list(f.qs)), 4)
 
     def test_relatedfilter_for_aliased_nested_relationships(self):
@@ -222,7 +221,7 @@ class RelatedFilterTests(TestCase):
         GET = {
             'author__name': 'user2',
         }
-        f = NoteFilterWithRelatedDifferentName(GET, queryset=Note.objects.all())
+        f = NoteFilterWithRelatedAlias(GET, queryset=Note.objects.all())
         self.assertEqual(len(list(f.qs)), 1)
         note = list(f.qs)[0]
         self.assertEqual(note.title, "Hello Test 4")

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -4,7 +4,7 @@ from django_filters import FilterSet as DFFilterSet
 from rest_framework_filters import FilterSet, filters
 
 from .testapp.filters import (
-    CFilter, CoverFilterWithRelated, NoteFilterWithAll, NoteFilterWithRelated,
+    CFilter, CoverFilter, NoteFilterWithAll, NoteFilterWithRelated,
     NoteFilterWithRelatedAll, NoteFilterWithRelatedAllDifferentFilterName,
     NoteFilterWithRelatedDifferentName, PageFilterWithAliasedNestedRelated,
     PersonFilter, PostFilter, UserFilter,
@@ -240,7 +240,7 @@ class RelatedFilterTests(TestCase):
         GET = {
             'post__note__author__username__endswith': 'user2'
         }
-        f = CoverFilterWithRelated(GET, queryset=Cover.objects.all())
+        f = CoverFilter(GET, queryset=Cover.objects.all())
         self.assertEqual(len(list(f.qs)), 1)
         cover = list(f.qs)[0]
         self.assertEqual(cover.comment, "Cover 2")

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -4,9 +4,9 @@ from django_filters import FilterSet as DFFilterSet
 from rest_framework_filters import FilterSet, filters
 
 from .testapp.filters import (
-    CFilter, CoverFilter, NoteFilterWithAll, NoteFilterWithRelated,
-    NoteFilterWithRelatedAll, NoteFilterWithAlias, NoteFilterWithRelatedAlias,
-    PageFilter, PersonFilter, PostFilter, UserFilter,
+    CFilter, CoverFilter, NoteFilter, NoteFilterWithAlias,
+    NoteFilterWithRelatedAlias, PageFilter, PersonFilter, PostFilter,
+    UserFilter,
 )
 from .testapp.models import A, B, C, Cover, Note, Page, Person, Post, Tag, User
 
@@ -32,18 +32,18 @@ class AllLookupsFilterTests(TestCase):
     def test_alllookupsfilter(self):
         # Test __iendswith
         GET = {'title__iendswith': '2'}
-        f = NoteFilterWithAll(GET, queryset=Note.objects.all())
+        f = NoteFilter(GET, queryset=Note.objects.all())
         self.assertEqual(len(list(f.qs)), 1)
         self.assertEqual(list(f.qs)[0].title, "Test 2")
 
         # Test __contains
         GET = {'title__contains': 'Test'}
-        f = NoteFilterWithAll(GET, queryset=Note.objects.all())
+        f = NoteFilter(GET, queryset=Note.objects.all())
         self.assertEqual(len(list(f.qs)), 4)
 
         # Test that the default exact filter works
         GET = {'title': 'Hello Test 3'}
-        f = NoteFilterWithAll(GET, queryset=Note.objects.all())
+        f = NoteFilter(GET, queryset=Note.objects.all())
         self.assertEqual(len(list(f.qs)), 1)
         self.assertEqual(list(f.qs)[0].title, "Hello Test 3")
 
@@ -135,13 +135,13 @@ class RelatedFilterTests(TestCase):
     def test_relatedfilter(self):
         # Test that the default exact filter works
         GET = {'author': User.objects.get(username='user2').pk}
-        f = NoteFilterWithRelated(GET, queryset=Note.objects.all())
+        f = NoteFilter(GET, queryset=Note.objects.all())
         self.assertEqual(len(list(f.qs)), 1)
         self.assertEqual(list(f.qs)[0].title, "Hello Test 4")
 
         # Test the username filter on the related UserFilter set.
         GET = {'author__username': 'user2'}
-        f = NoteFilterWithRelated(GET, queryset=Note.objects.all())
+        f = NoteFilter(GET, queryset=Note.objects.all())
         self.assertEqual(len(list(f.qs)), 1)
         self.assertEqual(list(f.qs)[0].title, "Hello Test 4")
 
@@ -150,28 +150,28 @@ class RelatedFilterTests(TestCase):
 
         # Test that the default exact filter works
         GET = {'author': User.objects.get(username='user2').pk}
-        f = NoteFilterWithRelatedAll(GET, queryset=Note.objects.all())
+        f = NoteFilter(GET, queryset=Note.objects.all())
         self.assertEqual(len(list(f.qs)), 1)
         note = list(f.qs)[0]
         self.assertEqual(note.title, "Hello Test 4")
 
         # Test the username filter on the related UserFilter set.
         GET = {'author__username': 'user2'}
-        f = NoteFilterWithRelatedAll(GET, queryset=Note.objects.all())
+        f = NoteFilter(GET, queryset=Note.objects.all())
         self.assertEqual(len(list(f.qs)), 1)
         self.assertEqual(list(f.qs)[0].title, "Hello Test 4")
 
         GET = {'author__username__endswith': '2'}
-        f = NoteFilterWithRelatedAll(GET, queryset=Note.objects.all())
+        f = NoteFilter(GET, queryset=Note.objects.all())
         self.assertEqual(len(list(f.qs)), 1)
         self.assertEqual(list(f.qs)[0].title, "Hello Test 4")
 
         GET = {'author__username__endswith': '1'}
-        f = NoteFilterWithRelatedAll(GET, queryset=Note.objects.all())
+        f = NoteFilter(GET, queryset=Note.objects.all())
         self.assertEqual(len(list(f.qs)), 3)
 
         GET = {'author__username__contains': 'user'}
-        f = NoteFilterWithRelatedAll(GET, queryset=Note.objects.all())
+        f = NoteFilter(GET, queryset=Note.objects.all())
         self.assertEqual(len(list(f.qs)), 4)
 
     def test_relatedfilter_for_related_alllookups_and_different_filter_name(self):
@@ -289,13 +289,13 @@ class RelatedFilterTests(TestCase):
         GET = {
             'author__nonexistent': 'foobar',
         }
-        f = NoteFilterWithRelated(GET, queryset=Note.objects.all())
+        f = NoteFilter(GET, queryset=Note.objects.all())
         self.assertEqual(len(list(f.qs)), 4)
 
         GET = {
             'author__nonexistent__isnull': 'foobar',
         }
-        f = NoteFilterWithRelated(GET, queryset=Note.objects.all())
+        f = NoteFilter(GET, queryset=Note.objects.all())
         self.assertEqual(len(list(f.qs)), 4)
 
     def test_related_filters_inheritance(self):

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -8,9 +8,7 @@ from rest_framework.views import APIView
 from rest_framework_filters import FilterSet, filters
 from rest_framework_filters.filterset import FilterSetMetaclass
 
-from .testapp.filters import (
-    NoteFilter, PostFilter, PostOverrideFilter, TagFilter, UserFilter,
-)
+from .testapp.filters import NoteFilter, PostFilter, TagFilter, UserFilter
 from .testapp.models import Note, Person, Post, Tag
 
 factory = APIRequestFactory()
@@ -339,33 +337,6 @@ class GetFilterSubsetTests(TestCase):
         self.assertIn('author', filter_subset)
         self.assertIn('content', filter_subset)
         self.assertEqual(len(filter_subset), 2)
-
-
-class FilterOverrideTests(TestCase):
-
-    def test_declared_filters(self):
-        F = PostOverrideFilter
-
-        # explicitly declared filters SHOULD NOT be overridden
-        self.assertIsInstance(
-            F.base_filters['declared_publish_date__isnull'],
-            filters.NumberFilter
-        )
-
-        # declared `AllLookupsFilter`s SHOULD generate filters that ARE overridden
-        self.assertIsInstance(
-            F.base_filters['all_declared_publish_date__isnull'],
-            filters.BooleanFilter
-        )
-
-    def test_dict_declaration(self):
-        F = PostOverrideFilter
-
-        # dictionary style declared filters SHOULD be overridden
-        self.assertIsInstance(
-            F.base_filters['publish_date__isnull'],
-            filters.BooleanFilter
-        )
 
 
 class FilterExclusionTests(TestCase):

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -9,8 +9,7 @@ from rest_framework_filters import FilterSet, filters
 from rest_framework_filters.filterset import FilterSetMetaclass
 
 from .testapp.filters import (
-    NoteFilterWithAll, NoteFilterWithRelated, PostFilter, PostOverrideFilter,
-    TagFilter, UserFilter,
+    NoteFilter, PostFilter, PostOverrideFilter, TagFilter, UserFilter,
 )
 from .testapp.models import Note, Person, Post, Tag
 
@@ -189,22 +188,22 @@ class GetParamFilterNameTests(TestCase):
 
     def test_related_filter(self):
         # 'exact' matches
-        name = NoteFilterWithRelated.get_param_filter_name('author')
+        name = NoteFilter.get_param_filter_name('author')
         self.assertEqual('author', name)
 
         # related attribute filters
-        name = NoteFilterWithRelated.get_param_filter_name('author__email')
+        name = NoteFilter.get_param_filter_name('author__email')
         self.assertEqual('author', name)
 
         # non-existent related filters should match, as it's the responsibility
         # of the related filterset to handle non-existent filters
-        name = NoteFilterWithRelated.get_param_filter_name('author__foobar')
+        name = NoteFilter.get_param_filter_name('author__foobar')
         self.assertEqual('author', name)
 
     def test_twice_removed_related_filter(self):
         class PostFilterWithDirectAuthor(PostFilter):
             note__author = filters.RelatedFilter(UserFilter)
-            note = filters.RelatedFilter(NoteFilterWithAll)
+            note = filters.RelatedFilter(NoteFilter)
 
             class Meta:
                 model = Post
@@ -230,8 +229,8 @@ class GetParamFilterNameTests(TestCase):
     def test_name_hiding(self):
         class PostFilterNameHiding(PostFilter):
             note__author = filters.RelatedFilter(UserFilter)
-            note = filters.RelatedFilter(NoteFilterWithAll)
-            note2 = filters.RelatedFilter(NoteFilterWithAll)
+            note = filters.RelatedFilter(NoteFilter)
+            note2 = filters.RelatedFilter(NoteFilter)
 
             class Meta:
                 model = Post
@@ -256,25 +255,25 @@ class GetParamFilterNameTests(TestCase):
 class GetRelatedFilterParamTests(TestCase):
 
     def test_regular_filter(self):
-        name, param = NoteFilterWithRelated.get_related_filter_param('title')
+        name, param = NoteFilter.get_related_filter_param('title')
         self.assertIsNone(name)
         self.assertIsNone(param)
 
     def test_related_filter_exact(self):
-        name, param = NoteFilterWithRelated.get_related_filter_param('author')
+        name, param = NoteFilter.get_related_filter_param('author')
         self.assertIsNone(name)
         self.assertIsNone(param)
 
     def test_related_filter_param(self):
-        name, param = NoteFilterWithRelated.get_related_filter_param('author__email')
+        name, param = NoteFilter.get_related_filter_param('author__email')
         self.assertEqual('author', name)
         self.assertEqual('email', param)
 
     def test_name_hiding(self):
         class PostFilterNameHiding(PostFilter):
             note__author = filters.RelatedFilter(UserFilter)
-            note = filters.RelatedFilter(NoteFilterWithAll)
-            note2 = filters.RelatedFilter(NoteFilterWithAll)
+            note = filters.RelatedFilter(NoteFilter)
+            note2 = filters.RelatedFilter(NoteFilter)
 
             class Meta:
                 model = Post
@@ -308,7 +307,7 @@ class GetFilterSubsetTests(TestCase):
 
     def test_related_subset(self):
         # related filters should only return the local RelatedFilter
-        filter_subset = NoteFilterWithRelated.get_filter_subset(['title', 'author', 'author__email'])
+        filter_subset = NoteFilter.get_filter_subset(['title', 'author', 'author__email'])
 
         self.assertIn('title', filter_subset)
         self.assertIn('author', filter_subset)
@@ -316,7 +315,7 @@ class GetFilterSubsetTests(TestCase):
 
     def test_non_filter_subset(self):
         # non-filter params should be ignored
-        filter_subset = NoteFilterWithRelated.get_filter_subset(['foobar'])
+        filter_subset = NoteFilter.get_filter_subset(['foobar'])
         self.assertEqual(len(filter_subset), 0)
 
     def test_metaclass_inheritance(self):

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -14,8 +14,8 @@ from rest_framework import serializers
 from rest_framework.renderers import JSONRenderer
 
 from .testapp.filters import (
-    AllLookupsPersonDateFilter, CoverFilterWithRelatedMethodFilter,
-    InLookupPersonFilter, PostFilter, UserFilter,
+    AllLookupsPersonDateFilter, CoverFilter, InLookupPersonFilter, PostFilter,
+    UserFilter,
 )
 from .testapp.models import Cover, Note, Person, Post, User
 
@@ -316,7 +316,7 @@ class FilterMethodTests(TestCase):
         GET = {
             'post__is_published': 'true'
         }
-        filterset = CoverFilterWithRelatedMethodFilter(GET, queryset=Cover.objects.all())
+        filterset = CoverFilter(GET, queryset=Cover.objects.all())
         results = list(filterset.qs)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].comment, "Cover 2")

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -15,8 +15,7 @@ from rest_framework.renderers import JSONRenderer
 
 from .testapp.filters import (
     AllLookupsPersonDateFilter, CoverFilterWithRelatedMethodFilter,
-    InSetLookupPersonIDFilter, InSetLookupPersonNameFilter, PostFilter,
-    UserFilter,
+    InLookupPersonFilter, PostFilter, UserFilter,
 )
 from .testapp.models import Cover, Note, Person, Post, User
 
@@ -185,7 +184,7 @@ class InLookupTests(TestCase):
         ALL_GET = {
             'pk__in': '{:d},{:d}'.format(p1, p2),
         }
-        f = InSetLookupPersonIDFilter(ALL_GET, queryset=Person.objects.all())
+        f = InLookupPersonFilter(ALL_GET, queryset=Person.objects.all())
         f = [x.pk for x in f.qs]
         self.assertEqual(len(f), 2)
         self.assertIn(p1, f)
@@ -194,14 +193,14 @@ class InLookupTests(TestCase):
         INVALID_GET = {
             'pk__in': '{:d},c{:d}'.format(p1, p2)
         }
-        f = InSetLookupPersonIDFilter(INVALID_GET, queryset=Person.objects.all())
+        f = InLookupPersonFilter(INVALID_GET, queryset=Person.objects.all())
         self.assertFalse(f.is_valid())
         self.assertEqual(f.qs.count(), 2)
 
         EXTRA_GET = {
             'pk__in': '{:d},{:d},{:d}'.format(p1, p2, p1 * p2)
         }
-        f = InSetLookupPersonIDFilter(EXTRA_GET, queryset=Person.objects.all())
+        f = InLookupPersonFilter(EXTRA_GET, queryset=Person.objects.all())
         f = [x.pk for x in f.qs]
         self.assertEqual(len(f), 2)
         self.assertIn(p1, f)
@@ -210,7 +209,7 @@ class InLookupTests(TestCase):
         DISORDERED_GET = {
             'pk__in': '{:d},{:d},{:d}'.format(p2, p2 * p1, p1)
         }
-        f = InSetLookupPersonIDFilter(DISORDERED_GET, queryset=Person.objects.all())
+        f = InLookupPersonFilter(DISORDERED_GET, queryset=Person.objects.all())
         f = [x.pk for x in f.qs]
         self.assertEqual(len(f), 2)
         self.assertIn(p1, f)
@@ -223,7 +222,7 @@ class InLookupTests(TestCase):
         ALL_GET = {
             'name__in': '{},{}'.format(p1, p2),
         }
-        f = InSetLookupPersonNameFilter(ALL_GET, queryset=Person.objects.all())
+        f = InLookupPersonFilter(ALL_GET, queryset=Person.objects.all())
         f = [x.name for x in f.qs]
         self.assertEqual(len(f), 2)
         self.assertIn(p1, f)
@@ -232,13 +231,13 @@ class InLookupTests(TestCase):
         NONEXISTENT_GET = {
             'name__in': '{},Foo{}'.format(p1, p2)
         }
-        f = InSetLookupPersonNameFilter(NONEXISTENT_GET, queryset=Person.objects.all())
+        f = InLookupPersonFilter(NONEXISTENT_GET, queryset=Person.objects.all())
         self.assertEqual(len(list(f.qs)), 1)
 
         EXTRA_GET = {
             'name__in': '{},{},{}'.format(p1, p2, p1 + p2)
         }
-        f = InSetLookupPersonNameFilter(EXTRA_GET, queryset=Person.objects.all())
+        f = InLookupPersonFilter(EXTRA_GET, queryset=Person.objects.all())
         f = [x.name for x in f.qs]
         self.assertEqual(len(f), 2)
         self.assertIn(p1, f)
@@ -247,7 +246,7 @@ class InLookupTests(TestCase):
         DISORDERED_GET = {
             'name__in': '{},{},{}'.format(p2, p2 + p1, p1)
         }
-        f = InSetLookupPersonNameFilter(DISORDERED_GET, queryset=Person.objects.all())
+        f = InLookupPersonFilter(DISORDERED_GET, queryset=Person.objects.all())
         f = [x.name for x in f.qs]
         self.assertEqual(len(f), 2)
         self.assertIn(p1, f)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -14,8 +14,7 @@ from rest_framework import serializers
 from rest_framework.renderers import JSONRenderer
 
 from .testapp.filters import (
-    AllLookupsPersonDateFilter, CoverFilter, InLookupPersonFilter, PostFilter,
-    UserFilter,
+    PersonFilter, CoverFilter, InLookupPersonFilter, PostFilter, UserFilter,
 )
 from .testapp.models import Cover, Note, Person, Post, User
 
@@ -69,7 +68,7 @@ class IsoDatetimeTests(TestCase):
         GET = {
             'date_joined__lte': date_str,
         }
-        f = AllLookupsPersonDateFilter(GET, queryset=Person.objects.all())
+        f = PersonFilter(GET, queryset=Person.objects.all())
         self.assertEqual(len(list(f.qs)), 2)
         p = list(f.qs)[0]
 
@@ -77,7 +76,7 @@ class IsoDatetimeTests(TestCase):
         GET = {
             'datetime_joined__lte': datetime_str,
         }
-        f = AllLookupsPersonDateFilter(GET, queryset=Person.objects.all())
+        f = PersonFilter(GET, queryset=Person.objects.all())
         self.assertEqual(len(list(f.qs)), 1)
         p = list(f.qs)[0]
         self.assertEqual(p.name, "John")
@@ -86,7 +85,7 @@ class IsoDatetimeTests(TestCase):
         GET = {
             'time_joined__lte': time_str,
         }
-        f = AllLookupsPersonDateFilter(GET, queryset=Person.objects.all())
+        f = PersonFilter(GET, queryset=Person.objects.all())
         self.assertEqual(len(list(f.qs)), 1)
         p = list(f.qs)[0]
         self.assertEqual(p.name, "John")
@@ -110,7 +109,7 @@ class IsoDatetimeTests(TestCase):
         GET = {
             'datetime_joined__lte': datetime_str,
         }
-        f = AllLookupsPersonDateFilter(GET, queryset=Person.objects.all())
+        f = PersonFilter(GET, queryset=Person.objects.all())
         self.assertEqual(len(list(f.qs)), 1)
         p = list(f.qs)[0]
         self.assertEqual(p.name, "John")

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -13,9 +13,9 @@ from django.utils.dateparse import parse_datetime, parse_time
 from rest_framework import serializers
 from rest_framework.renderers import JSONRenderer
 
-from .testapp.filters import (
-    PersonFilter, CoverFilter, InLookupPersonFilter, PostFilter, UserFilter,
-)
+from rest_framework_filters import AllLookupsFilter, FilterSet
+
+from .testapp.filters import CoverFilter, PostFilter, UserFilter
 from .testapp.models import Cover, Note, Person, Post, User
 
 today = datetime.date.today()
@@ -31,6 +31,25 @@ class PersonSerializer(serializers.ModelSerializer):
     class Meta:
         model = Person
         fields = ['date_joined', 'time_joined', 'datetime_joined']
+
+
+class PersonFilter(FilterSet):
+    date_joined = AllLookupsFilter(field_name='date_joined')
+    time_joined = AllLookupsFilter(field_name='time_joined')
+    datetime_joined = AllLookupsFilter(field_name='datetime_joined')
+
+    class Meta:
+        model = Person
+        fields = []
+
+
+class InLookupPersonFilter(FilterSet):
+    pk = AllLookupsFilter('id')
+    name = AllLookupsFilter('name')
+
+    class Meta:
+        model = Person
+        fields = []
 
 
 class IsoDatetimeTests(TestCase):

--- a/tests/testapp/filters.py
+++ b/tests/testapp/filters.py
@@ -154,11 +154,6 @@ class PersonFilter(FilterSet):
         queryset=Person.objects.all(),
     )
 
-    # date/datetime lookups
-    date_joined = AllLookupsFilter(field_name='date_joined')
-    time_joined = AllLookupsFilter(field_name='time_joined')
-    datetime_joined = AllLookupsFilter(field_name='datetime_joined')
-
     class Meta:
         model = Person
         fields = []
@@ -167,15 +162,6 @@ class PersonFilter(FilterSet):
 #############################################################
 # Extensions to django_filter fields for DRF.
 #############################################################
-class InLookupPersonFilter(FilterSet):
-    pk = AllLookupsFilter('id')
-    name = AllLookupsFilter('name')
-
-    class Meta:
-        model = Person
-        fields = []
-
-
 class PostOverrideFilter(FilterSet):
     declared_publish_date__isnull = filters.NumberFilter(field_name='publish_date', lookup_expr='isnull')
     all_declared_publish_date = filters.AllLookupsFilter(field_name='publish_date')

--- a/tests/testapp/filters.py
+++ b/tests/testapp/filters.py
@@ -212,15 +212,8 @@ class AllLookupsPersonDateFilter(FilterSet):
         fields = []
 
 
-class InSetLookupPersonIDFilter(FilterSet):
+class InLookupPersonFilter(FilterSet):
     pk = AllLookupsFilter('id')
-
-    class Meta:
-        model = Person
-        fields = []
-
-
-class InSetLookupPersonNameFilter(FilterSet):
     name = AllLookupsFilter('name')
 
     class Meta:

--- a/tests/testapp/filters.py
+++ b/tests/testapp/filters.py
@@ -157,15 +157,3 @@ class PersonFilter(FilterSet):
     class Meta:
         model = Person
         fields = []
-
-
-#############################################################
-# Extensions to django_filter fields for DRF.
-#############################################################
-class PostOverrideFilter(FilterSet):
-    declared_publish_date__isnull = filters.NumberFilter(field_name='publish_date', lookup_expr='isnull')
-    all_declared_publish_date = filters.AllLookupsFilter(field_name='publish_date')
-
-    class Meta:
-        model = Post
-        fields = {'publish_date': '__all__', }

--- a/tests/testapp/filters.py
+++ b/tests/testapp/filters.py
@@ -113,17 +113,9 @@ class CoverFilter(FilterSet):
         fields = []
 
 
-class PageFilterWithRelated(FilterSet):
+class PageFilter(FilterSet):
     title = filters.CharFilter(field_name='title')
     previous_page = RelatedFilter(PostFilter, field_name='previous_page', queryset=Post.objects.all())
-
-    class Meta:
-        model = Page
-        fields = []
-
-
-class PageFilterWithAliasedNestedRelated(FilterSet):
-    title = filters.CharFilter(field_name='title')
     two_pages_back = RelatedFilter(PostFilter, field_name='previous_page__previous_page', queryset=Page.objects.all())
 
     class Meta:

--- a/tests/testapp/filters.py
+++ b/tests/testapp/filters.py
@@ -16,14 +16,6 @@ class DFUserFilter(django_filters.FilterSet):
         fields = '__all__'
 
 
-class NoteFilterWithAll(FilterSet):
-    title = AllLookupsFilter(field_name='title')
-
-    class Meta:
-        model = Note
-        fields = []
-
-
 class UserFilter(FilterSet):
     username = AllLookupsFilter(field_name='username')
     email = filters.CharFilter(field_name='email')
@@ -35,17 +27,8 @@ class UserFilter(FilterSet):
         fields = []
 
 
-class NoteFilterWithRelated(FilterSet):
-    title = filters.CharFilter(field_name='title')
-    author = RelatedFilter(UserFilter, field_name='author', queryset=User.objects.all())
-
-    class Meta:
-        model = Note
-        fields = []
-
-
-class NoteFilterWithRelatedAll(FilterSet):
-    title = filters.CharFilter(field_name='title')
+class NoteFilter(FilterSet):
+    title = AllLookupsFilter(field_name='title')
     author = RelatedFilter(UserFilter, field_name='author', queryset=User.objects.all())
 
     class Meta:
@@ -68,7 +51,7 @@ class PostFilter(FilterSet):
     publish_date = filters.AllLookupsFilter()
     is_published = filters.BooleanFilter(field_name='publish_date', method='filter_is_published')
 
-    note = RelatedFilter(NoteFilterWithRelatedAll, field_name='note', queryset=Note.objects.all())
+    note = RelatedFilter(NoteFilter, field_name='note', queryset=Note.objects.all())
     tags = RelatedFilter(TagFilter, field_name='tags', queryset=Tag.objects.all())
 
     class Meta:

--- a/tests/testapp/filters.py
+++ b/tests/testapp/filters.py
@@ -104,16 +104,7 @@ class PostFilter(FilterSet):
         return qs.filter(**{lookup_expr: isnull})
 
 
-class CoverFilterWithRelatedMethodFilter(FilterSet):
-    comment = filters.CharFilter(field_name='comment')
-    post = RelatedFilter(PostFilter, field_name='post', queryset=Post.objects.all())
-
-    class Meta:
-        model = Cover
-        fields = []
-
-
-class CoverFilterWithRelated(FilterSet):
+class CoverFilter(FilterSet):
     comment = filters.CharFilter(field_name='comment')
     post = RelatedFilter(PostFilter, field_name='post', queryset=Post.objects.all())
 

--- a/tests/testapp/filters.py
+++ b/tests/testapp/filters.py
@@ -53,15 +53,6 @@ class NoteFilterWithRelatedAll(FilterSet):
         fields = []
 
 
-class NoteFilterWithRelatedAllDifferentFilterName(FilterSet):
-    title = filters.CharFilter(field_name='title')
-    writer = RelatedFilter(UserFilter, field_name='author', queryset=User.objects.all())
-
-    class Meta:
-        model = Note
-        fields = []
-
-
 class TagFilter(FilterSet):
     name = AllLookupsFilter(field_name='name')
 
@@ -114,7 +105,10 @@ class PageFilter(FilterSet):
         fields = []
 
 
-class UserFilterWithDifferentName(FilterSet):
+#############################################################
+# Aliased parameter names
+#############################################################
+class UserFilterWithAlias(FilterSet):
     name = filters.CharFilter(field_name='username')
 
     class Meta:
@@ -122,8 +116,17 @@ class UserFilterWithDifferentName(FilterSet):
         fields = []
 
 
-class NoteFilterWithRelatedDifferentName(FilterSet):
-    author = RelatedFilter(UserFilterWithDifferentName, field_name='author', queryset=User.objects.all())
+class NoteFilterWithAlias(FilterSet):
+    title = filters.CharFilter(field_name='title')
+    writer = RelatedFilter(UserFilter, field_name='author', queryset=User.objects.all())
+
+    class Meta:
+        model = Note
+        fields = []
+
+
+class NoteFilterWithRelatedAlias(FilterSet):
+    author = RelatedFilter(UserFilterWithAlias, field_name='author', queryset=User.objects.all())
 
     class Meta:
         model = Note

--- a/tests/testapp/filters.py
+++ b/tests/testapp/filters.py
@@ -25,19 +25,10 @@ class NoteFilterWithAll(FilterSet):
 
 
 class UserFilter(FilterSet):
-    username = filters.CharFilter(field_name='username')
+    username = AllLookupsFilter(field_name='username')
     email = filters.CharFilter(field_name='email')
     last_login = filters.AllLookupsFilter()
     is_active = filters.BooleanFilter(field_name='is_active')
-
-    class Meta:
-        model = User
-        fields = []
-
-
-class UserFilterWithAll(FilterSet):
-    username = AllLookupsFilter(field_name='username')
-    email = filters.CharFilter(field_name='email')
 
     class Meta:
         model = User
@@ -55,7 +46,7 @@ class NoteFilterWithRelated(FilterSet):
 
 class NoteFilterWithRelatedAll(FilterSet):
     title = filters.CharFilter(field_name='title')
-    author = RelatedFilter(UserFilterWithAll, field_name='author', queryset=User.objects.all())
+    author = RelatedFilter(UserFilter, field_name='author', queryset=User.objects.all())
 
     class Meta:
         model = Note
@@ -64,7 +55,7 @@ class NoteFilterWithRelatedAll(FilterSet):
 
 class NoteFilterWithRelatedAllDifferentFilterName(FilterSet):
     title = filters.CharFilter(field_name='title')
-    writer = RelatedFilter(UserFilterWithAll, field_name='author', queryset=User.objects.all())
+    writer = RelatedFilter(UserFilter, field_name='author', queryset=User.objects.all())
 
     class Meta:
         model = Note

--- a/tests/testapp/filters.py
+++ b/tests/testapp/filters.py
@@ -185,15 +185,7 @@ class PersonFilter(FilterSet):
         queryset=Person.objects.all(),
     )
 
-    class Meta:
-        model = Person
-        fields = []
-
-
-#############################################################
-# Extensions to django_filter fields for DRF.
-#############################################################
-class AllLookupsPersonDateFilter(FilterSet):
+    # date/datetime lookups
     date_joined = AllLookupsFilter(field_name='date_joined')
     time_joined = AllLookupsFilter(field_name='time_joined')
     datetime_joined = AllLookupsFilter(field_name='datetime_joined')
@@ -203,6 +195,9 @@ class AllLookupsPersonDateFilter(FilterSet):
         fields = []
 
 
+#############################################################
+# Extensions to django_filter fields for DRF.
+#############################################################
 class InLookupPersonFilter(FilterSet):
     pk = AllLookupsFilter('id')
     name = AllLookupsFilter('name')

--- a/tests/testapp/filters.py
+++ b/tests/testapp/filters.py
@@ -212,16 +212,6 @@ class AllLookupsPersonDateFilter(FilterSet):
         fields = []
 
 
-class ExplicitLookupsPersonDateFilter(FilterSet):
-    date_joined = AllLookupsFilter(field_name='date_joined')
-    time_joined = AllLookupsFilter(field_name='time_joined')
-    datetime_joined = AllLookupsFilter(field_name='datetime_joined')
-
-    class Meta:
-        model = Person
-        fields = []
-
-
 class InSetLookupPersonIDFilter(FilterSet):
     pk = AllLookupsFilter('id')
 

--- a/tests/testapp/views.py
+++ b/tests/testapp/views.py
@@ -3,7 +3,7 @@ from rest_framework import pagination, viewsets
 
 from rest_framework_filters import backends
 
-from .filters import DFUserFilter, NoteFilterWithRelatedAll, UserFilterWithAll
+from .filters import DFUserFilter, NoteFilterWithRelatedAll, UserFilter
 from .models import Note, User
 from .serializers import NoteSerializer, UserSerializer
 
@@ -43,7 +43,7 @@ class UserViewSet(viewsets.ModelViewSet):
     queryset = User.objects.all()
     serializer_class = UserSerializer
     filter_backends = (backends.RestFrameworkFilterBackend, )
-    filter_class = UserFilterWithAll
+    filter_class = UserFilter
 
 
 class NoteViewSet(viewsets.ModelViewSet):

--- a/tests/testapp/views.py
+++ b/tests/testapp/views.py
@@ -3,7 +3,7 @@ from rest_framework import pagination, viewsets
 
 from rest_framework_filters import backends
 
-from .filters import DFUserFilter, NoteFilterWithRelatedAll, UserFilter
+from .filters import DFUserFilter, NoteFilter, UserFilter
 from .models import Note, User
 from .serializers import NoteSerializer, UserSerializer
 
@@ -50,4 +50,4 @@ class NoteViewSet(viewsets.ModelViewSet):
     queryset = Note.objects.all()
     serializer_class = NoteSerializer
     filter_backends = (backends.RestFrameworkFilterBackend, )
-    filter_class = NoteFilterWithRelatedAll
+    filter_class = NoteFilter


### PR DESCRIPTION
Filtersets located in the testapp have been consolidated into a smaller set of more generic filtersets. For example, there's no reason `NoteFilterWithAll` and `NoteFilterWithRelated` exist as a single `NoteFilter`.

Additional changes:
- Filters for regression tests have been moved to that test module
- The tests and filterset for the no loner extant `.fix_filter_field()` have been removed