### PR TITLE
Add 'RelatedFilter' import of related filterset by name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -177,10 +177,10 @@ In the following example, the set of departments is restricted to those in the u
         department = filters.RelatedFilter(filterset=DepartmentFilter, queryset=departments)
         ...
 
-Recursive relationships
-"""""""""""""""""""""""
+Recursive & Circular relationships
+""""""""""""""""""""""""""""""""""
 
-Recursive relations are also supported. It may be necessary to specify the full module path.
+Recursive relations are also supported. Provide the module path as a string in place of the filterset class.
 
 .. code-block:: python
 
@@ -190,6 +190,19 @@ Recursive relations are also supported. It may be necessary to specify the full 
 
         class Meta:
             model = Person
+
+
+This feature is also useful for circular relationships, where a related filterset may not yet be created. Note that
+you can pass the related filterset by name if it's located in the same module as the parent filterset.
+
+.. code-block:: python
+
+    class BlogFilter(filters.FilterSet):
+        post = filters.RelatedFilter('PostFilter', queryset=Post.objects.all())
+
+    class PostFilter(filters.FilterSet):
+        blog = filters.RelatedFilter('BlogFilter', queryset=Blog.objects.all())
+
 
 Supporting ``Filter.method``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/rest_framework_filters/filters.py
+++ b/rest_framework_filters/filters.py
@@ -1,7 +1,7 @@
 from django_filters.rest_framework.filters import *  # noqa
 from django_filters.rest_framework.filters import Filter, ModelChoiceFilter
 
-from rest_framework_filters.utils import import_class
+from rest_framework_filters.utils import import_class, relative_class_path
 
 ALL_LOOKUPS = '__all__'
 
@@ -23,7 +23,8 @@ class RelatedFilter(AutoFilter, ModelChoiceFilter):
     def filterset():
         def fget(self):
             if isinstance(self._filterset, str):
-                self._filterset = import_class(self._filterset)
+                path = relative_class_path(self.parent, self._filterset)
+                self._filterset = import_class(path)
             return self._filterset
 
         def fset(self, value):

--- a/rest_framework_filters/utils.py
+++ b/rest_framework_filters/utils.py
@@ -1,3 +1,5 @@
+from importlib import import_module
+
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.expressions import Expression
 from django.db.models.lookups import Transform
@@ -5,8 +7,8 @@ from django.db.models.lookups import Transform
 
 def import_class(path):
     module_path, class_name = path.rsplit('.', 1)
-    class_name = str(class_name)  # Ensure not unicode on py2.x
-    module = __import__(module_path, fromlist=[class_name], level=0)
+    module = import_module(module_path)
+
     return getattr(module, class_name)
 
 

--- a/rest_framework_filters/utils.py
+++ b/rest_framework_filters/utils.py
@@ -12,6 +12,16 @@ def import_class(path):
     return getattr(module, class_name)
 
 
+def relative_class_path(cls, path):
+    if '.' in path:
+        return path
+
+    if not isinstance(cls, type):
+        cls = type(cls)
+
+    return '%s.%s' % (cls.__module__, path)
+
+
 def lookups_for_field(model_field):
     """
     Generates a list of all possible lookup expressions for a model field.

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -11,6 +11,12 @@ from .testapp.filters import (
 from .testapp.models import A, B, C, Cover, Note, Page, Person, Post, Tag, User
 
 
+class LocalTagFilter(FilterSet):
+    class Meta:
+        model = Tag
+        fields = []
+
+
 class AllLookupsFilterTests(TestCase):
 
     @classmethod
@@ -364,6 +370,17 @@ class RelatedFilterTests(TestCase):
         self.assertEqual(len(f.form.errors.keys()), 2)
         self.assertIn('note__author', f.form.errors)
         self.assertIn('pk', f.form.errors)
+
+    def test_relative_filterset_path(self):
+        # Test that RelatedFilter can import FilterSets by name from its parent's module
+        class PostFilter(FilterSet):
+            tags = filters.RelatedFilter('LocalTagFilter', queryset=Tag.objects.all())
+
+        f = PostFilter(queryset=Post.objects.all())
+        f = f.filters['tags'].filterset
+
+        self.assertEqual(f.__module__, 'tests.test_filtering')
+        self.assertEqual(f.__name__, 'LocalTagFilter')
 
 
 class MiscTests(TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,6 +14,23 @@ class ImportClassTests(TestCase):
         self.assertIs(cls, Note)
 
 
+class RelativeClassPathTests(TestCase):
+    def test_is_full_path(self):
+        path = utils.relative_class_path(None, 'a.b.c')
+
+        self.assertEqual(path, 'a.b.c')
+
+    def test_prepend_relative_class(self):
+        path = utils.relative_class_path(Note, 'Test')
+
+        self.assertEqual(path, 'tests.testapp.models.Test')
+
+    def test_prepend_relative_instance(self):
+        path = utils.relative_class_path(Note(), 'Test')
+
+        self.assertEqual(path, 'tests.testapp.models.Test')
+
+
 class LookupsForFieldTests(TestCase):
     def test_standard_field(self):
         model_field = Person._meta.get_field('name')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,15 @@ from rest_framework_filters import utils
 from .testapp.models import Note, Person
 
 
+class ImportClassTests(TestCase):
+    def test_simple(self):
+        cls = utils.import_class('tests.testapp.models.Note')
+
+        self.assertEqual(cls.__module__, 'tests.testapp.models')
+        self.assertEqual(cls.__name__, 'Note')
+        self.assertIs(cls, Note)
+
+
 class LookupsForFieldTests(TestCase):
     def test_standard_field(self):
         model_field = Person._meta.get_field('name')

--- a/tests/testapp/filters.py
+++ b/tests/testapp/filters.py
@@ -121,28 +121,28 @@ class NoteFilterWithRelatedAlias(FilterSet):
 #############################################################
 class AFilter(FilterSet):
     title = filters.CharFilter(field_name='title')
-    b = RelatedFilter('tests.testapp.filters.BFilter', field_name='b', queryset=B.objects.all())
+    b = RelatedFilter('BFilter', field_name='b', queryset=B.objects.all())
 
     class Meta:
         model = A
         fields = []
 
 
-class CFilter(FilterSet):
-    title = filters.CharFilter(field_name='title')
-    a = RelatedFilter(AFilter, field_name='a', queryset=A.objects.all())
-
-    class Meta:
-        model = C
-        fields = []
-
-
 class BFilter(FilterSet):
     name = AllLookupsFilter(field_name='name')
-    c = RelatedFilter(CFilter, field_name='c', queryset=C.objects.all())
+    c = RelatedFilter('CFilter', field_name='c', queryset=C.objects.all())
 
     class Meta:
         model = B
+        fields = []
+
+
+class CFilter(FilterSet):
+    title = filters.CharFilter(field_name='title')
+    a = RelatedFilter('AFilter', field_name='a', queryset=A.objects.all())
+
+    class Meta:
+        model = C
         fields = []
 
 


### PR DESCRIPTION
Add the ability to import related filtersets by name (instead of by full class path) when defining a relationship. For example:

```python
class BlogFilter(filters.FilterSet):
    post = filters.RelatedFilter('PostFilter', queryset=Post.objects.all())

class PostFilter(filters.FilterSet):
    blog = filters.RelatedFilter('BlogFilter', queryset=Blog.objects.all())
```

The caveat is that the filtersets must be located in the same module. If that cannot be guaranteed, relationships can still be defined wit the full class path.