### PR TITLE
Test related to-many behavior

### DIFF
--- a/tests/related/data.py
+++ b/tests/related/data.py
@@ -1,0 +1,89 @@
+from operator import attrgetter
+
+from ..testapp.models import Blog, Post
+
+
+class RelationshipData:
+    """
+    Mixin for providing the data for the relationship tests.
+
+    Posts have two factors:
+    - A: title__contains=Lennon
+    - B: publish_date__year=2008
+
+    There are four possible types of posts:
+    - postA:  A   B
+    - postB:  A  ~B
+    - postC: ~A   B
+    - postD: ~A  ~B
+
+    Ther are 15 unique combinations of blogs using the above four posts:
+    A, B, C, D, AB, AC, AD, BC, BD, CD, ABC, ABD, ACD, BCD, ABCD
+    1, 2, 3, 4, 5,  6,  7,  8,  9,  10, 11,  12,  13,  14,  15
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        b = Blog.objects.create(pk=1,  name='Blog A')
+        cls.postA(b)
+
+        b = Blog.objects.create(pk=2,  name='Blog B')
+        cls.postB(b)
+
+        b = Blog.objects.create(pk=3,  name='Blog C')
+        cls.postC(b)
+
+        b = Blog.objects.create(pk=4,  name='Blog D')
+        cls.postD(b)
+
+        b = Blog.objects.create(pk=5,  name='Blog AB')
+        cls.postA(b), cls.postB(b)
+
+        b = Blog.objects.create(pk=6,  name='Blog AC')
+        cls.postA(b), cls.postC(b)
+
+        b = Blog.objects.create(pk=7,  name='Blog AD')
+        cls.postA(b), cls.postD(b)
+
+        b = Blog.objects.create(pk=8,  name='Blog BC')
+        cls.postB(b), cls.postC(b)
+
+        b = Blog.objects.create(pk=9,  name='Blog BD')
+        cls.postB(b), cls.postD(b)
+
+        b = Blog.objects.create(pk=10, name='Blog CD')
+        cls.postC(b), cls.postD(b)
+
+        b = Blog.objects.create(pk=11, name='Blog ABC')
+        cls.postA(b), cls.postB(b), cls.postC(b)
+
+        b = Blog.objects.create(pk=12, name='Blog ABD')
+        cls.postA(b), cls.postB(b), cls.postD(b)
+
+        b = Blog.objects.create(pk=13, name='Blog ACD')
+        cls.postA(b), cls.postC(b), cls.postD(b)
+
+        b = Blog.objects.create(pk=14, name='Blog BCD')
+        cls.postB(b), cls.postC(b), cls.postD(b)
+
+        b = Blog.objects.create(pk=15, name='Blog ABCD')
+        cls.postA(b), cls.postB(b), cls.postC(b), cls.postD(b)
+
+    @classmethod
+    def postA(cls, blog):
+        Post.objects.create(blog=blog, title='Something about Lennon', publish_date='2008-01-01')
+
+    @classmethod
+    def postB(cls, blog):
+        Post.objects.create(blog=blog, title='Something about Lennon', publish_date='2010-01-01')
+
+    @classmethod
+    def postC(cls, blog):
+        Post.objects.create(blog=blog, title='Ringo was a Starr', publish_date='2008-01-01')
+
+    @classmethod
+    def postD(cls, blog):
+        Post.objects.create(blog=blog, title='Ringo was a Starr', publish_date='2010-01-01')
+
+    def verify(self, qs, expected):
+        self.assertQuerysetEqual(qs, expected, attrgetter('pk'), False)

--- a/tests/related/test_exclude.py
+++ b/tests/related/test_exclude.py
@@ -1,5 +1,8 @@
+import unittest
+
 from django.test import TestCase
 
+from tests.testapp.filters import BlogFilter
 from tests.testapp.models import Blog, Post
 
 from .data import RelationshipData
@@ -104,3 +107,12 @@ class ExcludeTests(RelationshipData, TestCase):
         )
 
         self.verify(q5, self.NOT_CORRECT_ONE)
+
+    # Test behavior
+    @unittest.expectedFailure
+    def test_reverse_fk(self):
+        GET = {
+            'post__title__contains!': 'Lennon',
+            'post__publish_date__year!': '2008',
+        }
+        self.verify(BlogFilter(GET).qs, self.NOT_CORRECT_ONE)

--- a/tests/related/test_exclude.py
+++ b/tests/related/test_exclude.py
@@ -1,0 +1,106 @@
+from django.test import TestCase
+
+from tests.testapp.models import Blog, Post
+
+from .data import RelationshipData
+
+
+class ExcludeTests(RelationshipData, TestCase):
+    """
+    Test assumptions for excluding data across a to-many relationship.
+
+    Given: GET /blogs?post__title__contains!=Lennon&post__publish_date__year!=2008
+    Find: All blogs that *do not* have articles published in 2008 about Lennon
+
+    Posts have two factors:
+    - A: title__contains=Lennon
+    - B: publish_date__year=2008
+
+    There are four possible types of posts:
+    - postA:  A   B
+    - postB:  A  ~B
+    - postC: ~A   B
+    - postD: ~A  ~B
+
+    Ther are 15 unique combinations of blogs using the above four posts:
+    A, B, C, D, AB, AC, AD, BC, BD, CD, ABC, ABD, ACD, BCD, ABCD
+    1, 2, 3, 4, 5,  6,  7,  8,  9,  10, 11,  12,  13,  14,  15
+    """
+
+    # match blogs where *no* entry matches *all* of the factors (not A)
+    CORRECT = [2, 3, 4, 8, 9, 10, 14]
+
+    # match blogs where *no* entry matches *any* of the factors (not A, not B, not C)
+    NOT_CORRECT_ANY = [4]
+
+    # match blogs where *an* entry matches *none* of the factors (D)
+    NOT_CORRECT_ONE = [4, 7, 9, 10, 12, 13, 14, 15]
+
+    def test_single_exclude(self):
+        """
+        Verify that exclusion is not equivalent
+        """
+        # q1 should be equivalent to q2/q4 and *not* q3/q5
+        q1 = Blog.objects.exclude(post__title__contains='Lennon')
+
+        # nested join
+        q2 = Blog.objects.exclude(post__in=Post.objects.filter(title__contains='Lennon'))
+        q3 = Blog.objects.filter(post__in=Post.objects.exclude(title__contains='Lennon'))
+
+        # nested subquery
+        q4 = Blog.objects.exclude(pk__in=Post.objects.filter(title__contains='Lennon').values('blog'))
+        q5 = Blog.objects.filter(pk__in=Post.objects.exclude(title__contains='Lennon').values('blog'))
+
+        # C, D, CD *all* entries do not have a title containing 'Lennon'
+        self.verify(q1, [3, 4, 10])
+        self.verify(q2, [3, 4, 10])
+        self.verify(q4, [3, 4, 10])
+
+        # These have *an* post where the title does not contain 'Lennon'
+        self.verify(q3.distinct(), [3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+        self.verify(q5.distinct(), [3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+
+    def test_chained_join_statements(self):
+        q1 = Blog.objects \
+                 .exclude(post__title__contains='Lennon') \
+                 .exclude(post__publish_date__year=2008)
+
+        self.verify(q1, self.NOT_CORRECT_ANY)
+
+    def test_nested_join_outer_exclude(self):
+        q2 = Blog.objects.exclude(
+            post__in=Post.objects
+                         .filter(title__contains='Lennon')
+                         .filter(publish_date__year=2008)
+        )
+
+        self.verify(q2, self.CORRECT)
+
+    def test_nested_join_inner_exclude(self):
+        q3 = Blog.objects.filter(
+            post__in=Post.objects
+                         .exclude(title__contains='Lennon')
+                         .exclude(publish_date__year=2008)
+        )
+
+        self.verify(q3, self.NOT_CORRECT_ONE)
+
+    def test_nested_subquery_outer_exclude(self):
+        q4 = Blog.objects.exclude(
+            pk__in=Post.objects
+                       .filter(title__contains='Lennon')
+                       .filter(publish_date__year=2008)
+                       .values('blog')
+        )
+
+        self.verify(q4, self.CORRECT)
+
+    def test_nested_subquery_inner_exclude(self):
+        q5 = Blog.objects.filter(
+            pk__in=Post.objects
+                       .exclude(title__contains='Lennon')
+                       .exclude(publish_date__year=2008)
+                       .values('blog')
+        )
+
+        self.verify(q5, self.NOT_CORRECT_ONE)

--- a/tests/related/test_filter.py
+++ b/tests/related/test_filter.py
@@ -1,5 +1,8 @@
+import unittest
+
 from django.test import TestCase
 
+from tests.testapp.filters import BlogFilter
 from tests.testapp.models import Blog, Post
 
 from .data import RelationshipData
@@ -72,3 +75,12 @@ class FilterTests(RelationshipData, TestCase):
         )
 
         self.verify(q3, self.CORRECT)
+
+    # Test behavior
+    @unittest.expectedFailure
+    def test_reverse_fk(self):
+        GET = {
+            'post__title__contains': 'Lennon',
+            'post__publish_date__year': '2008',
+        }
+        self.verify(BlogFilter(GET).qs, self.CORRECT)

--- a/tests/related/test_filter.py
+++ b/tests/related/test_filter.py
@@ -1,0 +1,74 @@
+from django.test import TestCase
+
+from tests.testapp.models import Blog, Post
+
+from .data import RelationshipData
+
+
+class FilterTests(RelationshipData, TestCase):
+    """
+    Test assumptions for filtering data across a to-many relationship.
+
+    Given: GET /blogs?post__title__contains=Lennon&post__publish_date__year=2008
+    Find: All blogs that have articles published in 2008 about Lennon
+
+    Posts have two factors:
+    - A: title__contains=Lennon
+    - B: publish_date__year=2008
+
+    There are four possible types of posts:
+    - postA:  A   B
+    - postB:  A  ~B
+    - postC: ~A   B
+    - postD: ~A  ~B
+
+    Ther are 15 unique combinations of blogs using the above four posts:
+    A, B, C, D, AB, AC, AD, BC, BD, CD, ABC, ABD, ACD, BCD, ABCD
+    1, 2, 3, 4, 5,  6,  7,  8,  9,  10, 11,  12,  13,  14,  15
+    """
+
+    # match blogs where entries match all conditions (A)
+    CORRECT = [1, 5, 6, 7, 11, 12, 13, 15]
+
+    # match blogs where all of the conditions occur (A, B+C)
+    NOT_CORRECT = [1, 5, 6, 7, 8, 11, 12, 13, 14, 15]
+
+    def test_single_filter(self):
+        """
+        Verify that the following queries are equivalent
+        """
+        q1 = Blog.objects.filter(post__title__contains='Lennon')
+        q2 = Blog.objects.filter(post__in=Post.objects.filter(title__contains='Lennon'))
+        q3 = Blog.objects.filter(pk__in=Post.objects.filter(title__contains='Lennon').values('blog'))
+
+        expected = [1, 2, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15]
+
+        self.verify(q1.distinct(), expected)
+        self.verify(q2.distinct(), expected)
+        self.verify(q3, expected)
+
+    def test_chained_join_statements(self):
+        q1 = Blog.objects \
+            .filter(post__title__contains='Lennon') \
+            .filter(post__publish_date__year=2008)
+
+        self.verify(q1.distinct(), self.NOT_CORRECT)
+
+    def test_nested_join(self):
+        q2 = Blog.objects.filter(
+            post__in=Post.objects
+                         .filter(title__contains='Lennon')
+                         .filter(publish_date__year=2008)
+        )
+
+        self.verify(q2, self.CORRECT)
+
+    def test_nested_subquery(self):
+        q3 = Blog.objects.filter(
+            pk__in=Post.objects
+                       .filter(title__contains='Lennon')
+                       .filter(publish_date__year=2008)
+                       .values('blog')
+        )
+
+        self.verify(q3, self.CORRECT)

--- a/tests/testapp/filters.py
+++ b/tests/testapp/filters.py
@@ -5,7 +5,7 @@ from rest_framework_filters import filters
 from rest_framework_filters.filters import AllLookupsFilter, RelatedFilter
 from rest_framework_filters.filterset import LOOKUP_SEP, FilterSet
 
-from .models import A, B, C, Cover, Note, Page, Person, Post, Tag, User
+from .models import A, B, Blog, C, Cover, Note, Page, Person, Post, Tag, User
 
 
 class DFUserFilter(django_filters.FilterSet):
@@ -44,9 +44,18 @@ class TagFilter(FilterSet):
         fields = []
 
 
+class BlogFilter(FilterSet):
+    name = AllLookupsFilter(field_name='name')
+    post = RelatedFilter('PostFilter', field_name='post', queryset=Post.objects.all())
+
+    class Meta:
+        model = Blog
+        fields = []
+
+
 class PostFilter(FilterSet):
     # Used for Related filter and Filter.method regression tests
-    title = filters.CharFilter(field_name='title')
+    title = filters.AllLookupsFilter(field_name='title')
 
     publish_date = filters.AllLookupsFilter()
     is_published = filters.BooleanFilter(field_name='publish_date', method='filter_is_published')

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -12,11 +12,16 @@ class Tag(models.Model):
     name = models.CharField(max_length=100)
 
 
+class Blog(models.Model):
+    name = models.CharField(max_length=100)
+
+
 class Post(models.Model):
     title = models.CharField(max_length=100)
     content = models.TextField()
     publish_date = models.DateField(null=True)
 
+    blog = models.ForeignKey(Blog, null=True, on_delete=models.CASCADE)
     author = models.ForeignKey(User, null=True, on_delete=models.CASCADE)
     note = models.ForeignKey(Note, null=True, on_delete=models.CASCADE)
     tags = models.ManyToManyField(Tag)


### PR DESCRIPTION
Add tests for filtering across to-many relationships. Includes:
- A few tests for filtering across to-many relationships w/ filtersets. Note that these are currently expected failures, and will be fixed with the related filtering rework.
- Tests that describe assumptions about the behavior of filtering across to-many relationships. These are used to help validate the expected behavior of filtersets.

ref #217