### PR TITLE
Fix 'FilterSet.override_filters()' behavior when not bound

### DIFF
--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -224,7 +224,9 @@ class FilterSet(rest_framework.FilterSet, metaclass=FilterSetMetaclass):
 
     @contextmanager
     def override_filters(self):
-        if self.is_bound:
+        if not self.is_bound:
+            yield
+        else:
             orig_filters = self.filters
             self.filters = self.request_filters
             yield

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -339,6 +339,22 @@ class GetFilterSubsetTests(TestCase):
         self.assertEqual(len(filter_subset), 2)
 
 
+class OverrideFiltersTests(TestCase):
+
+    def test_bound(self):
+        f = PostFilter({})
+
+        with f.override_filters():
+            self.assertEqual(len(f.filters), 0)
+
+    def test_not_bound(self):
+        f = PostFilter(None)
+
+        with f.override_filters():
+            self.assertGreater(len(f.filters), 1)
+            self.assertIn('title', f.filters)
+
+
 class FilterExclusionTests(TestCase):
 
     @classmethod


### PR DESCRIPTION
Fix `.override_filters()` when the filterset is not bound, add tests.