### PR TITLE
Add Django 2.1 to test matrix, update DRF/django-filter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,9 +51,9 @@ Requirements
 ------------
 
 * **Python**: 3.4, 3.5, 3.6
-* **Django**: 1.11, 2.0
-* **DRF**: 3.6, 3.7
-* **django-filter**: 2.0.0.dev1
+* **Django**: 1.11, 2.0, 2.1b1
+* **DRF**: 3.8
+* **django-filter**: 2.0
 
 
 Installation

--- a/rest_framework_filters/backends.py
+++ b/rest_framework_filters/backends.py
@@ -15,7 +15,7 @@ def noop(self):
 
 
 class RestFrameworkFilterBackend(backends.DjangoFilterBackend):
-    default_filter_set = FilterSet
+    filterset_base = FilterSet
 
     @property
     def template(self):
@@ -26,23 +26,23 @@ class RestFrameworkFilterBackend(backends.DjangoFilterBackend):
     @contextmanager
     def patch_for_rendering(self, request):
         """
-        Patch `get_filter_class()` so the resulting filterset does not perform
+        Patch `get_filterset_class()` so the resulting filterset does not perform
         filter expansion during form rendering.
         """
-        original = self.get_filter_class
+        original = self.get_filterset_class
 
-        def get_filter_class(view, queryset=None):
-            filter_class = original(view, queryset)
-            filter_class.override_filters = noop
+        def get_filterset_class(view, queryset=None):
+            filterset_class = original(view, queryset)
+            filterset_class.override_filters = noop
 
-            return filter_class
+            return filterset_class
 
-        self.get_filter_class = get_filter_class
+        self.get_filterset_class = get_filterset_class
         yield
-        self.get_filter_class = original
+        self.get_filterset_class = original
 
     def to_html(self, request, queryset, view):
-        # patching the behavior of `get_filter_class()` in this method allows
+        # patching the behavior of `get_filterset_class()` in this method allows
         # us to avoid maintenance issues with code duplication.
         with self.patch_for_rendering(request):
             return super(RestFrameworkFilterBackend, self).to_html(request, queryset, view)

--- a/rest_framework_filters/utils.py
+++ b/rest_framework_filters/utils.py
@@ -78,7 +78,10 @@ def lookups_for_transform(transform):
 
 def lookahead(iterable):
     it = iter(iterable)
-    current = next(it)
+    try:
+        current = next(it)
+    except StopIteration:
+        return
 
     for value in it:
         yield current, True

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'djangorestframework',
-        'django-filter>=2.0.0.dev1',
+        'django-filter>=2.0',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/tests/perf/views.py
+++ b/tests/perf/views.py
@@ -12,11 +12,11 @@ class DFNoteViewSet(viewsets.ModelViewSet):
     queryset = Note.objects.all()
     serializer_class = NoteSerializer
     filter_backends = (df_backends.DjangoFilterBackend, )
-    filter_class = NoteFilterWithExplicitRelated
+    filterset_class = NoteFilterWithExplicitRelated
 
 
 class DRFFNoteViewSet(viewsets.ModelViewSet):
     queryset = Note.objects.all()
     serializer_class = NoteSerializer
     filter_backends = (drf_backends.RestFrameworkFilterBackend, )
-    filter_class = NoteFilterWithRelatedAll
+    filterset_class = NoteFilterWithRelatedAll

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -23,29 +23,29 @@ class BackendTest(APITestCase):
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]['username'], 'user1')
 
-    def test_filter_fields_reusability(self):
-        # Ensure auto-generated FilterSet is reusable w/ filter_fields. See:
+    def test_filterset_fields_reusability(self):
+        # Ensure auto-generated FilterSet is reusable w/ filterset_fields. See:
         # https://github.com/philipn/django-rest-framework-filters/issues/81
 
-        # Ensure that the filter_fields aren't altered
-        self.assertDictEqual(views.FilterFieldsUserViewSet.filter_fields, {'username': '__all__'})
+        # Ensure that the filterset_fields aren't altered
+        self.assertDictEqual(views.FilterFieldsUserViewSet.filterset_fields, {'username': '__all__'})
 
         response = self.client.get('/ff-users/', {'username': 'user1'}, content_type='json')
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]['username'], 'user1')
-        self.assertDictEqual(views.FilterFieldsUserViewSet.filter_fields, {'username': '__all__'})
+        self.assertDictEqual(views.FilterFieldsUserViewSet.filterset_fields, {'username': '__all__'})
 
         response = self.client.get('/ff-users/', {'username': 'user1'}, content_type='json')
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]['username'], 'user1')
-        self.assertDictEqual(views.FilterFieldsUserViewSet.filter_fields, {'username': '__all__'})
+        self.assertDictEqual(views.FilterFieldsUserViewSet.filterset_fields, {'username': '__all__'})
 
     def test_backend_output_sanity(self):
         """
         Sanity check to ensure backend can at least render something without crashing.
         """
         class SimpleViewSet(views.FilterFieldsUserViewSet):
-            filter_fields = ['username']
+            filterset_fields = ['username']
 
         view = SimpleViewSet(action_map={})
         backend = view.filter_backends[0]
@@ -78,7 +78,7 @@ class BackendTest(APITestCase):
                 fields = ['username']
 
         class ViewSet(views.FilterFieldsUserViewSet):
-            filter_class = RequestCheck
+            filterset_class = RequestCheck
 
         view = ViewSet(action_map={})
         backend = view.filter_backends[0]
@@ -92,7 +92,7 @@ class BackendTest(APITestCase):
                 fields = ['username']
 
         class ViewSet(views.FilterFieldsUserViewSet):
-            filter_class = RequestCheck
+            filterset_class = RequestCheck
 
         view = ViewSet(action_map={})
         backend = view.filter_backends[0]

--- a/tests/testapp/views.py
+++ b/tests/testapp/views.py
@@ -14,14 +14,14 @@ class DFUserViewSet(viewsets.ModelViewSet):
     queryset = User.objects.all()
     serializer_class = UserSerializer
     filter_backends = (backends.RestFrameworkFilterBackend, )
-    filter_class = DFUserFilter
+    filterset_class = DFUserFilter
 
 
 class FilterFieldsUserViewSet(viewsets.ModelViewSet):
     queryset = User.objects.all()
     serializer_class = UserSerializer
     filter_backends = (backends.RestFrameworkFilterBackend, )
-    filter_fields = {
+    filterset_fields = {
         'username': '__all__',
     }
 
@@ -29,7 +29,7 @@ class FilterFieldsUserViewSet(viewsets.ModelViewSet):
 class ComplexFilterFieldsUserViewSet(FilterFieldsUserViewSet):
     queryset = User.objects.order_by('pk')
     filter_backends = (backends.ComplexFilterBackend, )
-    filter_fields = {
+    filterset_fields = {
         'id': '__all__',
         'username': '__all__',
         'email': '__all__',
@@ -43,11 +43,11 @@ class UserViewSet(viewsets.ModelViewSet):
     queryset = User.objects.all()
     serializer_class = UserSerializer
     filter_backends = (backends.RestFrameworkFilterBackend, )
-    filter_class = UserFilter
+    filterset_class = UserFilter
 
 
 class NoteViewSet(viewsets.ModelViewSet):
     queryset = Note.objects.all()
     serializer_class = NoteSerializer
     filter_backends = (backends.RestFrameworkFilterBackend, )
-    filter_class = NoteFilter
+    filterset_class = NoteFilter

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    ; Test two versions of DRF against Django's LTS
-    py{34,35,36}-django{111}-restframework{36,37},
-    py{34,35,36}-django{20}-restframework{37},
+    py{34,35,36}-django111,
+    py{35,36,37}-django20,
+    py{35,36,37}-django21,
     performance, warnings, lint, dist
 
 [travis]
@@ -15,10 +15,10 @@ setenv =
     PYTHONDONTWRITEBYTECODE=1
 deps =
     coverage>=4.0
-    django111: django>=1.11,<2.0
-    django20: django>=2.0b1,<2.1
-    restframework36: djangorestframework>=3.6,<3.7
-    restframework37: djangorestframework>=3.7,<3.8
+    djangorestframework~=3.8
+    django111: django~=1.11
+    django20: django~=2.0
+    django21: django~=2.1b1
 
 
 [testenv:performance]


### PR DESCRIPTION
Update the test matrix. I've stopped testing against two versions of DRF since a) it complicates the test matrix, and b) we don't make use of DRF internals and the extra effort isn't worth it.

Fixes #238.