### PR TITLE
Minor cleanup

### DIFF
--- a/rest_framework_filters/filters.py
+++ b/rest_framework_filters/filters.py
@@ -7,18 +7,29 @@ ALL_LOOKUPS = '__all__'
 
 
 class AutoFilter(Filter):
-    def __init__(self, *args, **kwargs):
-        self.lookups = kwargs.pop('lookups', [])
+    """
+    Declarative alternative to using the `Meta.fields` dictionary syntax. These
+    fields are processed by the metaclass and resolved into per-lookup filters.
 
-        super(AutoFilter, self).__init__(*args, **kwargs)
+    `AutoFilter`s benefit from their declarative nature in that it is possible
+    to change the parameter name of the generated filters. This is not possible
+    with the `Meta.fields` syntax.
+    """
+
+    def __init__(self, *args, lookups=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.lookups = lookups or []
 
 
 class RelatedFilter(AutoFilter, ModelChoiceFilter):
-    def __init__(self, filterset, *args, **kwargs):
-        self.filterset = filterset
-        kwargs.setdefault('lookups', None)
+    """
+    A `ModelChoiceFilter` that defines a relationship to another `FilterSet`.
+    This related filterset is processed by the filter's `parent` instance, and
+    """
 
-        super(RelatedFilter, self).__init__(*args, **kwargs)
+    def __init__(self, filterset, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.filterset = filterset
 
     def filterset():
         def fget(self):
@@ -43,6 +54,4 @@ class RelatedFilter(AutoFilter, ModelChoiceFilter):
 
 class AllLookupsFilter(AutoFilter):
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault('lookups', ALL_LOOKUPS)
-
-        super(AllLookupsFilter, self).__init__(*args, **kwargs)
+        super().__init__(*args, lookups=ALL_LOOKUPS, **kwargs)

--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -24,6 +24,11 @@ class FilterSetMetaclass(filterset.FilterSetMetaclass):
 
     @classmethod
     def expand_auto_filters(cls, new_class):
+        """
+        Resolve `AutoFilter`s into their per-lookup filters. `AutoFilter`s are
+        a declarative alternative to the `Meta.fields` dictionary syntax, and
+        use the same machinery internally.
+        """
         # get reference to opts/declared filters
         orig_meta, orig_declared = new_class._meta, new_class.declared_filters
 

--- a/tests/testapp/filters.py
+++ b/tests/testapp/filters.py
@@ -2,7 +2,7 @@
 import django_filters
 
 from rest_framework_filters import filters
-from rest_framework_filters.filters import AllLookupsFilter, RelatedFilter
+from rest_framework_filters.filters import AutoFilter, RelatedFilter
 from rest_framework_filters.filterset import LOOKUP_SEP, FilterSet
 
 from .models import A, B, Blog, C, Cover, Note, Page, Person, Post, Tag, User
@@ -17,9 +17,9 @@ class DFUserFilter(django_filters.FilterSet):
 
 
 class UserFilter(FilterSet):
-    username = AllLookupsFilter(field_name='username')
+    username = AutoFilter(field_name='username', lookups='__all__')
     email = filters.CharFilter(field_name='email')
-    last_login = filters.AllLookupsFilter()
+    last_login = AutoFilter(lookups='__all__')
     is_active = filters.BooleanFilter(field_name='is_active')
 
     class Meta:
@@ -28,7 +28,7 @@ class UserFilter(FilterSet):
 
 
 class NoteFilter(FilterSet):
-    title = AllLookupsFilter(field_name='title')
+    title = AutoFilter(field_name='title', lookups='__all__')
     author = RelatedFilter(UserFilter, field_name='author', queryset=User.objects.all())
 
     class Meta:
@@ -37,7 +37,7 @@ class NoteFilter(FilterSet):
 
 
 class TagFilter(FilterSet):
-    name = AllLookupsFilter(field_name='name')
+    name = AutoFilter(field_name='name', lookups='__all__')
 
     class Meta:
         model = Tag
@@ -45,7 +45,7 @@ class TagFilter(FilterSet):
 
 
 class BlogFilter(FilterSet):
-    name = AllLookupsFilter(field_name='name')
+    name = AutoFilter(field_name='name', lookups='__all__')
     post = RelatedFilter('PostFilter', field_name='post', queryset=Post.objects.all())
 
     class Meta:
@@ -55,9 +55,9 @@ class BlogFilter(FilterSet):
 
 class PostFilter(FilterSet):
     # Used for Related filter and Filter.method regression tests
-    title = filters.AllLookupsFilter(field_name='title')
+    title = filters.AutoFilter(field_name='title', lookups='__all__')
 
-    publish_date = filters.AllLookupsFilter()
+    publish_date = filters.AutoFilter(lookups='__all__')
     is_published = filters.BooleanFilter(field_name='publish_date', method='filter_is_published')
 
     note = RelatedFilter(NoteFilter, field_name='note', queryset=Note.objects.all())
@@ -138,7 +138,7 @@ class AFilter(FilterSet):
 
 
 class BFilter(FilterSet):
-    name = AllLookupsFilter(field_name='name')
+    name = AutoFilter(field_name='name', lookups='__all__')
     c = RelatedFilter('CFilter', field_name='c', queryset=C.objects.all())
 
     class Meta:
@@ -156,7 +156,7 @@ class CFilter(FilterSet):
 
 
 class PersonFilter(FilterSet):
-    name = AllLookupsFilter(field_name='name')
+    name = AutoFilter(field_name='name', lookups='__all__')
     best_friend = RelatedFilter(
         'tests.testapp.filters.PersonFilter',
         field_name='best_friend',


### PR DESCRIPTION
- Add a few class/method docstrings.
- Replace some usage of `AllLookupsFilter` with `AutoFilter(lookups='__all__')`. This in prep for deprecating the former in favor of the latter.