### PR TITLE
Deprecate AllLookupsFilter in favor of AutoFilter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Unreleased:
 -----------
 
+* #242 Deprecate ``AllLookupsFilter``
 * #191 Fix ``name`` => ``field_name`` warnings
 
 

--- a/rest_framework_filters/filters.py
+++ b/rest_framework_filters/filters.py
@@ -1,3 +1,5 @@
+import warnings
+
 from django_filters.rest_framework.filters import *  # noqa
 from django_filters.rest_framework.filters import Filter, ModelChoiceFilter
 
@@ -55,3 +57,6 @@ class RelatedFilter(AutoFilter, ModelChoiceFilter):
 class AllLookupsFilter(AutoFilter):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, lookups=ALL_LOOKUPS, **kwargs)
+        warnings.warn(
+            "`AllLookupsFilter()` has been deprecated in favor of `AutoFilter(lookups='__all__')`.",
+            DeprecationWarning, stacklevel=2)

--- a/tests/perf/filters.py
+++ b/tests/perf/filters.py
@@ -22,7 +22,7 @@ class NoteFilterWithExplicitRelated(DFFilterSet):
 
 # drf-filters
 class UserFilterWithAll(DRFFilterSet):
-    username = filters.AllLookupsFilter()
+    username = filters.AutoFilter(lookups='__all__')
 
     class Meta:
         model = User
@@ -30,7 +30,7 @@ class UserFilterWithAll(DRFFilterSet):
 
 
 class NoteFilterWithRelatedAll(DRFFilterSet):
-    title = filters.AllLookupsFilter()
+    title = filters.AutoFilter(lookups='__all__')
     author = filters.RelatedFilter(UserFilterWithAll, queryset=User.objects.all())
 
     class Meta:

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -17,7 +17,7 @@ class LocalTagFilter(FilterSet):
         fields = []
 
 
-class AllLookupsFilterTests(TestCase):
+class AutoFilterTests(TestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -35,7 +35,7 @@ class AllLookupsFilterTests(TestCase):
         Note.objects.create(title="Hello Test 3", content="Test content 3", author=user1)
         Note.objects.create(title="Hello Test 4", content="Test content 4", author=user2)
 
-    def test_alllookupsfilter(self):
+    def test_all_lookups(self):
         # Test __iendswith
         GET = {'title__iendswith': '2'}
         f = NoteFilter(GET, queryset=Note.objects.all())
@@ -53,20 +53,20 @@ class AllLookupsFilterTests(TestCase):
         self.assertEqual(len(list(f.qs)), 1)
         self.assertEqual(list(f.qs)[0].title, "Hello Test 3")
 
-    def test_alllookups_filter_with_mixin(self):
+    def test_autofilter_with_mixin(self):
         # Mixin FilterSets should not error when no model is provided. See:
         # https://github.com/philipn/django-rest-framework-filters/issues/82
         class Mixin(FilterSet):
-            title = filters.AllLookupsFilter()
+            title = filters.AutoFilter(lookups='__all__')
 
         class Actual(Mixin):
             class Meta:
                 model = Note
                 fields = []
 
-        GET = {'title__contains': 'Test'}
+        GET = {'title__contains': 'Hello'}
         f = Actual(GET, queryset=Note.objects.all())
-        self.assertEqual(len(list(f.qs)), 4)
+        self.assertEqual(len(list(f.qs)), 2)
 
 
 class RelatedFilterTests(TestCase):
@@ -151,8 +151,8 @@ class RelatedFilterTests(TestCase):
         self.assertEqual(len(list(f.qs)), 1)
         self.assertEqual(list(f.qs)[0].title, "Hello Test 4")
 
-    def test_relatedfilter_for_related_alllookups(self):
-        # ensure that filters work for AllLookupsFilter across a RelatedFilter.
+    def test_relatedfilter_for_related_all_lookups(self):
+        # ensure that filters work for AutoFilter across a RelatedFilter.
 
         # Test that the default exact filter works
         GET = {'author': User.objects.get(username='user2').pk}
@@ -180,7 +180,7 @@ class RelatedFilterTests(TestCase):
         f = NoteFilter(GET, queryset=Note.objects.all())
         self.assertEqual(len(list(f.qs)), 4)
 
-    def test_relatedfilter_for_related_alllookups_and_different_filter_name(self):
+    def test_relatedfilter_for_related_all_lookups_and_different_filter_name(self):
         # Test that the default exact filter works
         GET = {
             'writer': User.objects.get(username='user2').pk,

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -42,14 +42,16 @@ class MetaclassTests(TestCase):
 
 class AutoFilterTests(TestCase):
     """
-    Test auto filter generation (`AllLookupsFilter`, `RelatedFilter`, '__all__').
+    Test auto filter generation (`AutoFilter`, `RelatedFilter`, '__all__').
     """
 
-    def test_alllookupsfilter_meta_fields_unmodified(self):
+    def test_autofilter_meta_fields_unmodified(self):
+        # The FilterSetMetaclass temporarily modifies the `FilterSet._meta` when
+        # processing auto filters. Ensure the `_meta` isn't permanently altered.
         f = []
 
         class F(FilterSet):
-            id = filters.AllLookupsFilter()
+            id = filters.AutoFilter(lookups='__all__')
 
             class Meta:
                 model = Note
@@ -57,19 +59,19 @@ class AutoFilterTests(TestCase):
 
         self.assertIs(F._meta.fields, f)
 
-    def test_alllookupsfilter_replaced(self):
+    def test_autofilter_replaced(self):
         # See: https://github.com/philipn/django-rest-framework-filters/issues/118
         class F(FilterSet):
-            id = filters.AllLookupsFilter()
+            id = filters.AutoFilter(lookups='__all__')
 
             class Meta:
                 model = Note
                 fields = []
 
-        self.assertIsInstance(F.declared_filters['id'], filters.AllLookupsFilter)
+        self.assertIsInstance(F.declared_filters['id'], filters.AutoFilter)
         self.assertIsInstance(F.base_filters['id'], filters.NumberFilter)
 
-    def test_alllookupsfilter_for_relation(self):
+    def test_all_lookups_for_relation(self):
         # See: https://github.com/philipn/django-rest-framework-filters/issues/84
         class F(FilterSet):
             class Meta:
@@ -81,10 +83,10 @@ class AutoFilterTests(TestCase):
         self.assertIsInstance(F.base_filters['author'], filters.ModelChoiceFilter)
         self.assertIsInstance(F.base_filters['author__in'], BaseInFilter)
 
-    def test_alllookupsfilter_for_related_field(self):
+    def test_autofilter_for_related_field(self):
         # See: https://github.com/philipn/django-rest-framework-filters/issues/127
         class F(FilterSet):
-            author = filters.AllLookupsFilter(field_name='author__last_name')
+            author = filters.AutoFilter(field_name='author__last_name', lookups='__all__')
 
             class Meta:
                 model = Note
@@ -108,7 +110,7 @@ class AutoFilterTests(TestCase):
         self.assertIsInstance(F.base_filters['author__in'], BaseInFilter)
 
     def test_relatedfilter_lookups(self):
-        # ensure that related filter is compatible with __all__ lookups.
+        # ensure that related filter is compatible with AutoFilter lookups.
         class F(FilterSet):
             author = filters.RelatedFilter(UserFilter, lookups='__all__')
 
@@ -155,12 +157,12 @@ class AutoFilterTests(TestCase):
 
         self.assertIs(F.base_filters['name'], f)
 
-    def test_declared_filter_persistence_with_alllookupsfilter(self):
-        # ensure that AllLookupsFilter does not overwrite declared filters.
+    def test_declared_filter_persistence_with_autofilter(self):
+        # ensure that AutoFilter does not overwrite declared filters.
         f = filters.Filter()
 
         class F(FilterSet):
-            id = filters.AllLookupsFilter()
+            id = filters.AutoFilter(lookups='__all__')
             id__in = f
 
             class Meta:

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -1,4 +1,5 @@
 import sys
+import warnings
 
 from django.test import TestCase
 from django_filters.filters import BaseInFilter
@@ -170,6 +171,20 @@ class AutoFilterTests(TestCase):
                 fields = []
 
         self.assertIs(F.base_filters['id__in'], f)
+
+    def test_alllookupsfilter_deprecation_warning(self):
+        message = ("`AllLookupsFilter()` has been deprecated in "
+                   "favor of `AutoFilter(lookups='__all__')`.")
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+
+            class F(FilterSet):
+                field = filters.AllLookupsFilter()
+
+        self.assertEqual(len(w), 1)
+        self.assertEqual(str(w[0].message), message)
+        self.assertIs(w[0].category, DeprecationWarning)
 
 
 class GetParamFilterNameTests(TestCase):

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -13,7 +13,7 @@ from django.utils.dateparse import parse_datetime, parse_time
 from rest_framework import serializers
 from rest_framework.renderers import JSONRenderer
 
-from rest_framework_filters import AllLookupsFilter, FilterSet
+from rest_framework_filters import AutoFilter, FilterSet
 
 from .testapp.filters import CoverFilter, PostFilter, UserFilter
 from .testapp.models import Cover, Note, Person, Post, User
@@ -34,9 +34,9 @@ class PersonSerializer(serializers.ModelSerializer):
 
 
 class PersonFilter(FilterSet):
-    date_joined = AllLookupsFilter(field_name='date_joined')
-    time_joined = AllLookupsFilter(field_name='time_joined')
-    datetime_joined = AllLookupsFilter(field_name='datetime_joined')
+    date_joined = AutoFilter(field_name='date_joined', lookups='__all__')
+    time_joined = AutoFilter(field_name='time_joined', lookups='__all__')
+    datetime_joined = AutoFilter(field_name='datetime_joined', lookups='__all__')
 
     class Meta:
         model = Person
@@ -44,8 +44,8 @@ class PersonFilter(FilterSet):
 
 
 class InLookupPersonFilter(FilterSet):
-    pk = AllLookupsFilter('id')
-    name = AllLookupsFilter('name')
+    pk = AutoFilter('id', lookups='__all__')
+    name = AutoFilter('name', lookups='__all__')
 
     class Meta:
         model = Person


### PR DESCRIPTION
Deprecate `AllLookupsFilter()` in favor of `AutoFilter(lookups='__all__')`. Currently, the former is just an alias of the latter, and there isn't much benefit in keeping it around.