### PR TITLE
Refactor filter subsetting

### DIFF
--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -74,7 +74,7 @@ class SubsetDisabledMixin:
     """
     @classmethod
     def get_filter_subset(cls, params, rel=None):
-        pass
+        return cls.base_filters
 
     @contextmanager
     def override_filters(self):
@@ -86,11 +86,7 @@ class FilterSet(rest_framework.FilterSet, metaclass=FilterSetMetaclass):
     def __init__(self, data=None, queryset=None, *, request=None, prefix=None, **kwargs):
         # Filter the `base_filters` by the desired filter subset. This reduces the cost
         # of initialization by reducing the number of filters that are deepcopied.
-        subset = self.get_filter_subset(data or {})
-        if subset:
-            self.base_filters = OrderedDict([
-                (k, v) for k, v in self.base_filters.items() if k in subset
-            ])
+        self.base_filters = self.get_filter_subset(data or {})
 
         super(FilterSet, self).__init__(data, queryset, request=request, prefix=prefix, **kwargs)
 
@@ -239,7 +235,7 @@ class FilterSet(rest_framework.FilterSet, metaclass=FilterSetMetaclass):
     @classmethod
     def get_filter_subset(cls, params):
         """
-        Returns a subset of filter names that should be initialized by the
+        Returns the subset of filters that should be initialized by the
         FilterSet, dependent on the requested `params`. This is useful when
         traversing FilterSet relationships, as it helps to minimize deepcopy
         overhead incurred when instantiating related FilterSets.
@@ -250,7 +246,9 @@ class FilterSet(rest_framework.FilterSet, metaclass=FilterSetMetaclass):
         # removed, as they indicate an unknown field eg, author__foobar__isnull
         filter_names = {cls.get_param_filter_name(param) for param in params}
         filter_names = {f for f in filter_names if f is not None}
-        return filter_names
+        return OrderedDict(
+            (k, v) for k, v in cls.base_filters.items() if k in filter_names
+        )
 
     @contextmanager
     def override_filters(self):

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -382,7 +382,7 @@ class RelatedFilterTests(TestCase):
         class PostFilter(FilterSet):
             tags = filters.RelatedFilter('LocalTagFilter', queryset=Tag.objects.all())
 
-        f = PostFilter(queryset=Post.objects.all())
+        f = PostFilter({'tags': ''}, queryset=Post.objects.all())
         f = f.filters['tags'].filterset
 
         self.assertEqual(f.__module__, 'tests.test_filtering')

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -400,8 +400,14 @@ class OverrideFiltersTests(TestCase):
         f = PostFilter(None)
 
         with f.override_filters():
-            self.assertGreater(len(f.filters), 1)
-            self.assertIn('title', f.filters)
+            self.assertEqual(len(f.filters), 0)
+
+    def test_subset_disabled(self):
+        f = PostFilter.disable_subset()(None)
+
+        with f.override_filters():
+            # The number of filters varies by Django version
+            self.assertGreater(len(f.filters), 30)
 
 
 class FilterExclusionTests(TestCase):

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -282,18 +282,22 @@ class IsNullLookupTests(TestCase):
         import django_filters.filters
 
         self.assertIsInstance(
-            UserFilter().filters['last_login__isnull'],
+            UserFilter.base_filters['last_login__isnull'],
             django_filters.filters.BooleanFilter
         )
 
         GET = {'last_login__isnull': 'false'}
         filterset = UserFilter(GET, queryset=User.objects.all())
+        filter_ = filterset.filters['last_login__isnull']
+        self.assertIsInstance(filter_, django_filters.filters.BooleanFilter)
         results = list(filterset.qs)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].username, 'user1')
 
         GET = {'last_login__isnull': 'true'}
         filterset = UserFilter(GET, queryset=User.objects.all())
+        filter_ = filterset.filters['last_login__isnull']
+        self.assertIsInstance(filter_, django_filters.filters.BooleanFilter)
         results = list(filterset.qs)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].username, 'user2')


### PR DESCRIPTION
Minor cleanup around filter subsetting. The `get_filter_subset` method now returns the `.base_filters` replacement dictionary instead of the set of filter names. Overriding just returns the original dictionary.