### PR TITLE
Improve RelatedFilter filterset imports

### DIFF
--- a/rest_framework_filters/filters.py
+++ b/rest_framework_filters/filters.py
@@ -1,9 +1,10 @@
 import warnings
 
+from django.utils.module_loading import import_string
 from django_filters.rest_framework.filters import *  # noqa
 from django_filters.rest_framework.filters import Filter, ModelChoiceFilter
 
-from rest_framework_filters.utils import import_class, relative_class_path
+from rest_framework_filters.utils import relative_class_path
 
 ALL_LOOKUPS = '__all__'
 
@@ -37,7 +38,7 @@ class RelatedFilter(AutoFilter, ModelChoiceFilter):
         def fget(self):
             if isinstance(self._filterset, str):
                 path = relative_class_path(self.parent, self._filterset)
-                self._filterset = import_class(path)
+                self._filterset = import_string(path)
             return self._filterset
 
         def fset(self, value):

--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -16,6 +16,10 @@ class FilterSetMetaclass(filterset.FilterSetMetaclass):
         new_class.auto_filters = cls.get_auto_filters(new_class)
         new_class.related_filters = cls.get_related_filters(new_class)
 
+        # see: :meth:`rest_framework_filters.filters.RelatedFilter.bind`
+        for f in new_class.related_filters.values():
+            f.bind(new_class)
+
         # If model is defined, process auto filters
         if new_class._meta.model is not None:
             cls.expand_auto_filters(new_class)

--- a/rest_framework_filters/utils.py
+++ b/rest_framework_filters/utils.py
@@ -3,16 +3,6 @@ from django.db.models.expressions import Expression
 from django.db.models.lookups import Transform
 
 
-def relative_class_path(cls, path):
-    if '.' in path:
-        return path
-
-    if not isinstance(cls, type):
-        cls = type(cls)
-
-    return '%s.%s' % (cls.__module__, path)
-
-
 def lookups_for_field(model_field):
     """
     Generates a list of all possible lookup expressions for a model field.

--- a/rest_framework_filters/utils.py
+++ b/rest_framework_filters/utils.py
@@ -1,15 +1,6 @@
-from importlib import import_module
-
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.expressions import Expression
 from django.db.models.lookups import Transform
-
-
-def import_class(path):
-    module_path, class_name = path.rsplit('.', 1)
-    module = import_module(module_path)
-
-    return getattr(module, class_name)
 
 
 def relative_class_path(cls, path):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,38 @@
+from django.test import TestCase
+from rest_framework_filters import FilterSet, filters
+
+
+class A(FilterSet):
+    c = filters.RelatedFilter('tests.test_filters.C')
+
+
+class B(FilterSet):
+    a = filters.RelatedFilter('A')
+
+
+class C(FilterSet):
+    b = filters.RelatedFilter(B)
+
+
+class RelatedFilterFiltersetTests(TestCase):
+    # Test all three argument styles, but mainly ensure:
+    # - `.filterset` is importable before parent FilterSet init
+    # - Relative `.filterset` imports are durable to inheritance
+
+    def subclass(self, cls):
+        return type('Subclass%s' % cls.__name__, (cls, ), {})
+
+    def test_filterset_absolute_import(self):
+        for cls in [A, self.subclass(A)]:
+            with self.subTest(cls=cls):
+                self.assertIs(cls.base_filters['c'].filterset, C)
+
+    def test_filterset_relative_import(self):
+        for cls in [B, self.subclass(B)]:
+            with self.subTest(cls=cls):
+                self.assertIs(cls.base_filters['a'].filterset, A)
+
+    def test_filterset_class(self):
+        for cls in [C, self.subclass(C)]:
+            with self.subTest(cls=cls):
+                self.assertIs(cls.base_filters['b'].filterset, B)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+
 from rest_framework_filters import FilterSet, filters
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,15 +5,6 @@ from rest_framework_filters import utils
 from .testapp.models import Note, Person
 
 
-class ImportClassTests(TestCase):
-    def test_simple(self):
-        cls = utils.import_class('tests.testapp.models.Note')
-
-        self.assertEqual(cls.__module__, 'tests.testapp.models')
-        self.assertEqual(cls.__name__, 'Note')
-        self.assertIs(cls, Note)
-
-
 class RelativeClassPathTests(TestCase):
     def test_is_full_path(self):
         path = utils.relative_class_path(None, 'a.b.c')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,23 +5,6 @@ from rest_framework_filters import utils
 from .testapp.models import Note, Person
 
 
-class RelativeClassPathTests(TestCase):
-    def test_is_full_path(self):
-        path = utils.relative_class_path(None, 'a.b.c')
-
-        self.assertEqual(path, 'a.b.c')
-
-    def test_prepend_relative_class(self):
-        path = utils.relative_class_path(Note, 'Test')
-
-        self.assertEqual(path, 'tests.testapp.models.Test')
-
-    def test_prepend_relative_instance(self):
-        path = utils.relative_class_path(Note(), 'Test')
-
-        self.assertEqual(path, 'tests.testapp.models.Test')
-
-
 class LookupsForFieldTests(TestCase):
     def test_standard_field(self):
         model_field = Person._meta.get_field('name')

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ deps =
     https://github.com/tomchristie/django-rest-framework/archive/master.tar.gz
 
 [testenv:isort]
-commands = isort --recursive --check-only rest_framework_filters tests {posargs}
+commands = isort --recursive --check-only rest_framework_filters tests {posargs:--diff}
 deps = isort
 
 [testenv:lint]


### PR DESCRIPTION
Filterset imports for related filters currently have two flaws:

- Relative imports are not durable to subclassing. 
- The related filtersets can only be accessed *after* the `parent` filterset is initialized.

This PR fixes that by binding the declaring FilterSet to the related filter during class creation.