### PR TITLE
Minor metaclass cleanup

### DIFF
--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -157,11 +157,9 @@ class FilterSet(rest_framework.FilterSet, metaclass=FilterSetMetaclass):
         if param[-1] == '!' and param[:-1] in cls.base_filters:
             return param[:-1]
 
-        # Fallback to matching against relationships. (author__username__endswith).
-        related_filters = cls.related_filters.keys()
-
-        # preference more specific filters. eg, `note__author` over `note`.
-        for name in reversed(sorted(related_filters)):
+        # Match against relationships. (author__username__endswith).
+        # Preference more specific filters. eg, `note__author` over `note`.
+        for name in reversed(sorted(cls.related_filters)):
             # we need to match against '__' to prevent eager matching against
             # like names. eg, note vs note2. Exact matches are handled above.
             if param.startswith("%s%s" % (name, LOOKUP_SEP)):
@@ -232,10 +230,8 @@ class FilterSet(rest_framework.FilterSet, metaclass=FilterSetMetaclass):
             (None, None)
 
         """
-        related_filters = cls.related_filters.keys()
-
         # preference more specific filters. eg, `note__author` over `note`.
-        for name in reversed(sorted(related_filters)):
+        for name in reversed(sorted(cls.related_filters)):
             # we need to match against '__' to prevent eager matching against
             # like names. eg, note vs note2. Exact matches are handled above.
             if param.startswith("%s%s" % (name, LOOKUP_SEP)):

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -165,7 +165,7 @@ class BackendRenderingTests(APITestCase):
         self.assertFalse(issubclass(filterset, SubsetDisabledMixin))
 
         # check that FilterSet.related_filters aren't modified
-        filterset = UserFilter.related_filters['notes'].filterset
+        filterset = UserFilter.base_filters['notes'].filterset
         self.assertTrue(issubclass(filterset, FilterSet))
         self.assertFalse(issubclass(filterset, SubsetDisabledMixin))
 

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -31,8 +31,6 @@ class MetaclassTests(TestCase):
     def test_metamethods(self):
         functions = [
             'expand_auto_filters',
-            'get_auto_filters',
-            'get_related_filters',
         ]
 
         for func in functions:


### PR DESCRIPTION
Changed the `auto_filters` and `related_filters` dicts into lists. Code should pull these values from `declared_filters` or `base_filters` and reference the filter name against the appropriate list. 

This cuts down a bit on the number of references to these filters and makes the code a little more consistent with itself.