### PR TITLE
Simplify codecov comment, fix coverage detection

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+comment:
+    layout: "reach"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,9 @@
 [coverage:run]
 branch = True
-source = rest_framework_filters
+source = .
 
 [coverage:report]
+include = rest_framework_filters/*
 show_missing = True
 
 [isort]


### PR DESCRIPTION
This is an attempt to fix codecov reports. Some files seem to be missing from the output, although they show up locally with `coverage report` or `coverage html`.