### PR TITLE
use django-filter version that supports python 2.7 for v0.10.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'djangorestframework',
-        'django-filter>=1.0.0',
+        'django-filter>=1.0.0,<=1.1.0',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
For issue #253

Might be nice to have a v1.10.3 for this and have a proper branch for 0.10.x.