### PR TITLE
Test Python 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 
 install:
   - travis_retry pip install -U six setuptools pip wheel
@@ -17,15 +18,15 @@ after_success:
 
 matrix:
   include:
-    - python: "3.6"
+    - python: "3.7"
       env: TOXENV="performance"
       script: tox -- -v 2
-    - python: "3.6"
+    - python: "3.7"
       env: TOXENV="warnings"
-    - python: "3.6"
+    - python: "3.7"
       env: TOXENV="isort,lint"
 
-    - python: "3.6"
+    - python: "3.7"
       env: TOXENV="dist"
       script:
         - python setup.py bdist_wheel

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Features
 Requirements
 ------------
 
-* **Python**: 3.4, 3.5, 3.6
+* **Python**: 3.4, 3.5, 3.6, 3.7
 * **Django**: 1.11, 2.0, 2.1
 * **DRF**: 3.9
 * **django-filter**: 2.0

--- a/tests/perf/tests.py
+++ b/tests/perf/tests.py
@@ -1,7 +1,7 @@
 import argparse
 from timeit import repeat
 
-from django.test import TestCase, override_settings
+from django.test import TestCase, override_settings, tag
 from rest_framework.test import APIRequestFactory
 
 from tests.perf import views
@@ -20,6 +20,7 @@ args, _ = parser.parse_known_args()
 verbosity = args.verbosity
 
 
+@tag('perf')
 class PerfTestMixin(object):
     """
     This mixin provides common setup for testing the performance differences

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
 unignore_outcomes = true
 
 [testenv]
-commands = coverage run manage.py test {posargs}
+commands = coverage run manage.py test --exclude-tag=perf {posargs}
 envdir = {toxworkdir}/venvs/{envname}
 setenv =
     PYTHONDONTWRITEBYTECODE=1
@@ -22,14 +22,14 @@ deps =
 
 
 [testenv:performance]
-commands = python manage.py test tests.perf {posargs}
+commands = python manage.py test --tag=perf {posargs}
 deps =
     django
     djangorestframework
 
 [testenv:warnings]
 ignore_outcome = True
-commands = python -Werror manage.py test {posargs}
+commands = python -Werror manage.py test --exclude-tag=perf {posargs}
 deps =
     https://github.com/django/django/archive/master.tar.gz
     https://github.com/tomchristie/django-rest-framework/archive/master.tar.gz
@@ -45,7 +45,7 @@ deps = flake8
 [testenv:dist]
 commands =
     twine check dist/*
-    python manage.py test --no-pkgroot {posargs}
+    python manage.py test --no-pkgroot --exclude-tag=perf {posargs}
 deps =
     django
     djangorestframework


### PR DESCRIPTION
Fixes #283. Python 3.7 is compatible - the issues only existed in the test suite.

Added `test_tilde_decoding`, which ensures tilde handling from both RFC 2396 & 3986 are supported (i.e., `~` and `%7E` are treated identically).