### PR TITLE
Fix 0.11.x packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.rst
+global-exclude __pycache__
+global-exclude *.py[co]


### PR DESCRIPTION
The 0.11.x packaging was broken due to two combined factors. 
- The current master added a `templatetags` subpackage
- The 0.11.x and older code didn't have a package manifest

As a result, when packaging 0.11, the .pyc files from the current master were erroneously included in the build output. Adding a manifest and excluding the pyc files fixes this.

This fixes #295 