### PR TITLE
Fix AutoFilter accidentally munging declared filter names

### DIFF
--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -79,8 +79,8 @@ class FilterSetMetaclass(filterset.FilterSetMetaclass):
 
         This method name is slightly inaccurate since it handles both
         :class:`rest_framework_filters.filters.AutoFilter` and
-        :class:`rest_framework_filters.filters.RelatedFilter`, which both
-        support per-lookup filter generation.
+        :class:`rest_framework_filters.filters.BaseRelatedFilter`, as well as
+        their subclasses, which all support per-lookup filter generation.
 
         Args:
             new_class: The ``FilterSet`` class to generate filters for.

--- a/tests/perf/README.md
+++ b/tests/perf/README.md
@@ -13,6 +13,10 @@ relationships via `RelatedFilter`. The intent is to provide some assurance that:
 The performance tests have been isolated from the main test suite so that they can be
 ran independently. Simply run:
 
+    $ tox -e performance
+
+Or more directly:
+
     $ python manage.py test tests.perf
 
 

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -63,8 +63,17 @@ class AutoFilterTests(TestCase):
                 model = Note
                 fields = []
 
+        class Subclass(Actual):
+            class Meta:
+                model = Note
+                fields = []
+
         GET = {'title__contains': 'Hello'}
         f = Actual(GET, queryset=Note.objects.all())
+        self.assertEqual(len(list(f.qs)), 2)
+
+        GET = {'title__contains': 'Hello'}
+        f = Subclass(GET, queryset=Note.objects.all())
         self.assertEqual(len(list(f.qs)), 2)
 
 

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -314,7 +314,7 @@ class RelatedFilterTests(TestCase):
 
     def test_related_filters_inheritance(self):
         class ChildFilter(PostFilter):
-            foo = filters.RelatedFilter(PostFilter)
+            foo = filters.RelatedFilter(NoteFilter, field_name='note')
 
         self.assertEqual(['author', 'note', 'tags'], list(PostFilter.related_filters))
         self.assertEqual(['author', 'note', 'tags', 'foo'], list(ChildFilter.related_filters))

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -364,38 +364,47 @@ class GetParamFilterNameTests(TestCase):
 
 class GetFilterSubsetTests(TestCase):
 
+    class NoteFilter(FilterSet):
+        # A simpler version of NoteFilter that doesn't use autofilter expansion
+        title = filters.CharFilter()
+        author = filters.RelatedFilter(UserFilter)
+
+        class Meta:
+            model = Note
+            fields = []
+
     def test_get_subset(self):
-        filter_subset = UserFilter.get_filter_subset(['email'])
+        filter_subset = self.NoteFilter.get_filter_subset(['title'])
 
         # ensure that the FilterSet subset only contains the requested fields
-        self.assertEqual(list(filter_subset), ['email'])
+        self.assertEqual(list(filter_subset), ['title'])
 
     def test_related_subset(self):
         # related filters should only return the local RelatedFilter
-        filter_subset = NoteFilter.get_filter_subset(['title', 'author', 'author__email'])
+        filter_subset = self.NoteFilter.get_filter_subset(['title', 'author', 'author__email'])
 
         self.assertEqual(list(filter_subset), ['title', 'author'])
 
     def test_non_filter_subset(self):
         # non-filter params should be ignored
-        filter_subset = NoteFilter.get_filter_subset(['foobar'])
+        filter_subset = self.NoteFilter.get_filter_subset(['foobar'])
         self.assertEqual(list(filter_subset), [])
 
     def test_subset_ordering(self):
         # sanity check ordering of base filters
-        filter_subset = [f for f in NoteFilter.base_filters if f in ['title', 'author']]
+        filter_subset = [f for f in self.NoteFilter.base_filters if f in ['title', 'author']]
         self.assertEqual(list(filter_subset), ['title', 'author'])
 
         # ensure that the ordering of the subset is the same as the base filters
-        filter_subset = NoteFilter.get_filter_subset(['title', 'author'])
+        filter_subset = self.NoteFilter.get_filter_subset(['title', 'author'])
         self.assertEqual(list(filter_subset), ['title', 'author'])
 
         # ensure reverse argument order does not change subset ordering
-        filter_subset = NoteFilter.get_filter_subset(['author', 'title'])
+        filter_subset = self.NoteFilter.get_filter_subset(['author', 'title'])
         self.assertEqual(list(filter_subset), ['title', 'author'])
 
         # ensure related filters do not change subset ordering
-        filter_subset = NoteFilter.get_filter_subset(['author__email', 'author', 'title'])
+        filter_subset = self.NoteFilter.get_filter_subset(['author__email', 'author', 'title'])
         self.assertEqual(list(filter_subset), ['title', 'author'])
 
     def test_metaclass_inheritance(self):


### PR DESCRIPTION
Fixes #234. In short, auto filters negatively interact with declared filters, and may erroneously create new filters. e.g, 

```python
class MyFilter(FilterSet):
    pk = AutoFilter(field_name='id')
    individual = CharFilter()
```

The above would also create a `indivpkual` filter.