### PR TITLE
Add nested related filters to docs schema

### DIFF
--- a/rest_framework_filters/backends.py
+++ b/rest_framework_filters/backends.py
@@ -1,7 +1,8 @@
-
+import warnings
 from contextlib import contextmanager
 from django_filters.rest_framework import backends
 
+from django_filters import compat
 from .filterset import FilterSet
 
 
@@ -32,3 +33,30 @@ class DjangoFilterBackend(backends.DjangoFilterBackend):
         # us to avoid maintenance issues with code duplication.
         with self.patched_filter_class(request):
             return super(DjangoFilterBackend, self).filter_queryset(request, queryset, view)
+
+    def get_schema_fields(self, view):
+        # Use the filter_class expanded filters property instead of
+        # base filters so that the nested related filter can be included
+        assert compat.coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
+        assert compat.coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
+
+        filter_class = getattr(view, 'filter_class', None)
+        if filter_class is None:
+            try:
+                filter_class = self.get_filter_class(view, view.get_queryset())
+            except Exception:
+                warnings.warn(
+                    "{} is not compatible with schema generation".format(view.__class__)
+                )
+                filter_class = None
+
+        return [] if not filter_class else [
+            compat.coreapi.Field(
+                name=field_name,
+                required=field.extra['required'],
+                location='query',
+                schema=self.get_coreschema_field(field)
+                # expanded_filters in place of base_filters
+            ) for field_name, field in filter_class.expanded_filters.items()
+        ]
+

--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -70,6 +70,17 @@ class FilterSetMetaclass(filterset.FilterSetMetaclass):
             ])
         return self._related_filters
 
+    @property
+    def expanded_filters(self):
+        if '_expanded_filters' not in self.__dict__:
+            self._expanded_filters = self.base_filters.copy()
+            for filter_name, f in self.related_filters.items():
+                del self._expanded_filters[filter_name]
+                for related_name, related_f in six.iteritems(f.filterset.expanded_filters):
+                    related_name = LOOKUP_SEP.join([filter_name, related_name])
+                    self._expanded_filters[related_name] = related_f
+        return self._expanded_filters
+
 
 class FilterSet(six.with_metaclass(FilterSetMetaclass, rest_framework.FilterSet)):
     _subset_cache = {}


### PR DESCRIPTION
Currently, nested filters are not shown in swagger docs because they are not added to the OpenAPI schema. With this PR, the filters are expanded and added when generating the docs