### PR TITLE
Add support for passing a method to filters generated through AutoFilter

### DIFF
--- a/rest_framework_filters/filters.py
+++ b/rest_framework_filters/filters.py
@@ -44,9 +44,10 @@ class AutoFilter:
     """
     creation_counter = 0
 
-    def __init__(self, field_name=None, *, lookups=None):
+    def __init__(self, field_name=None, *, lookups=None, method=None):
         self.field_name = field_name
         self.lookups = lookups or []
+        self.method = method
 
         self.creation_counter = AutoFilter.creation_counter
         AutoFilter.creation_counter += 1

--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -103,6 +103,16 @@ class FilterSetMetaclass(filterset.FilterSetMetaclass):
             # replace the field name with the param name from the filerset
             gen_name = gen_name.replace(f.field_name, filter_name, 1)
 
+            if f.method:
+                # Override method for auto-generated filters.
+                gen_f.method = f.method
+
+                # Skip if lookup expression is `exact` since it is equivalent to no lookup
+                if gen_f.lookup_expr != "exact":
+                    # Update field name to also include lookup expr.
+                    gen_f.field_name = "{field_name}__{lookup_expr}".format(field_name=f.field_name,
+                                                                            lookup_expr=gen_f.lookup_expr)
+
             # do not overwrite declared filters
             if gen_name not in orig_declared:
                 expanded[gen_name] = gen_f


### PR DESCRIPTION
Allow AutoFilter to accept a `method` param and pass it to the generated filters.

The same behaviour for the following
```
class MyFilter(FilterSet):
    title__contains = CharFilter(method='custom_pk_filter')
    title__endswith = CharFilter(method='custom_pk_filter')

    def custom_pk_filter(self, qs, field, value):
        pass
```

Can now be done as 
```
class MyFilter(FilterSet):
    title = AutoFilter(lookups=['contains', 'endswith'], method='custom_pk_filter')

    def custom_pk_filter(self, qs, field, value):
        pass
```
