### PR TITLE
Handle RelatedFilter.distinct

### DIFF
--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -308,6 +308,10 @@ class FilterSet(rest_framework.FilterSet, metaclass=FilterSetMetaclass):
             subquery = related_filterset.qs.values(to_field_name)
             queryset = queryset.filter(**{lookup_expr: subquery})
 
+            # handle disinct
+            if self.related_filters[related_name].distinct:
+                queryset = queryset.distinct()
+
         return queryset
 
     def get_form_class(self):

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -98,7 +98,7 @@ class RelatedFilterTests(TestCase):
         ########################################################################
         # Create posts #########################################################
         post1 = Post.objects.create(note=note1, content="Test content in post 1")
-        Post.objects.create(note=note2, content="Test content in post 2")
+        post2 = Post.objects.create(note=note2, content="Test content in post 2")
         post3 = Post.objects.create(note=note4, content="Test content in post 3")
 
         ########################################################################
@@ -121,6 +121,13 @@ class RelatedFilterTests(TestCase):
 
         post1.tags.set([t1, t3])
         post3.tags.set([t3])
+
+        ########################################################################
+        # ManyToMany distinct ##################################################
+        t4 = Tag.objects.create(name="test1")
+        t5 = Tag.objects.create(name="test2")
+
+        post2.tags.set([t4, t5])
 
         ########################################################################
         # Recursive relations ##################################################
@@ -298,6 +305,15 @@ class RelatedFilterTests(TestCase):
         self.assertEqual(len(list(f.qs)), 2)
         contents = set([post.content for post in f.qs])
         self.assertEqual(contents, {'Test content in post 1', 'Test content in post 3'})
+
+    def test_m2m_distinct(self):
+        GET = {
+            'tags__name__startswith': 'test',
+        }
+        f = PostFilter(GET, queryset=Post.objects.all())
+        self.assertEqual(len(list(f.qs)), 1)
+        contents = set([post.content for post in f.qs])
+        self.assertEqual(contents, {'Test content in post 2'})
 
     def test_nonexistent_related_field(self):
         """

--- a/tests/testapp/filters.py
+++ b/tests/testapp/filters.py
@@ -66,7 +66,7 @@ class PostFilter(FilterSet):
 
     author = RelatedFilter(UserFilter, field_name='author', queryset=User.objects.all())
     note = RelatedFilter(NoteFilter, field_name='note', queryset=Note.objects.all())
-    tags = RelatedFilter(TagFilter, field_name='tags', queryset=Tag.objects.all())
+    tags = RelatedFilter(TagFilter, field_name='tags', queryset=Tag.objects.all(), distinct=True)
 
     class Meta:
         model = Post


### PR DESCRIPTION
Allows for `RelatedFilter` to-many relations to take advantage of the `distinct` argument.

Travis build: https://travis-ci.org/github/philipn/django-rest-framework-filters/builds/716047086