### PR TITLE
Fix RecursionError for circular self relationships

### DIFF
--- a/rest_framework_filters/filterset.py
+++ b/rest_framework_filters/filterset.py
@@ -217,6 +217,10 @@ class FilterSet(rest_framework.FilterSet, metaclass=FilterSetMetaclass):
         if not param:
             return param
 
+        # check that param is not the rel.
+        if param == rel:
+            return None
+
         # strip the rel prefix from the param name.
         prefix = '%s%s' % (rel or '', LOOKUP_SEP)
         if rel and param.startswith(prefix):

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -281,6 +281,16 @@ class RelatedFilterTests(TestCase):
         self.assertEqual(c.title, "C1")
 
     def test_direct_recursive_relation(self):
+        # see: https://github.com/philipn/django-rest-framework-filters/issues/333
+        GET = {
+            'best_friend': 1
+        }
+        f = PersonFilter(GET, queryset=Person.objects.all())
+        self.assertEqual(len(list(f.qs)), 1)
+        p = list(f.qs)[0]
+        self.assertEqual(p.name, "Mark")
+
+    def test_direct_recursive_relation__lookup(self):
         GET = {
             'best_friend__name__endswith': 'hn'
         }

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -10,7 +10,8 @@ from rest_framework_filters import FilterSet, filters
 from rest_framework_filters.filterset import FilterSetMetaclass, SubsetDisabledMixin
 
 from .testapp.filters import (
-    AFilter, NoteFilter, NoteFilterWithAlias, PostFilter, TagFilter, UserFilter,
+    AFilter, NoteFilter, NoteFilterWithAlias, PersonFilter, PostFilter, TagFilter,
+    UserFilter,
 )
 from .testapp.models import Note, Person, Post, Tag, User
 
@@ -354,6 +355,15 @@ class GetParamFilterNameTests(TestCase):
     def test_relationship_regular_filter(self):
         name = UserFilter.get_param_filter_name('author__email', rel='author')
         self.assertEqual('email', name)
+
+    def test_recursive_self_filter(self):
+        name = PersonFilter.get_param_filter_name('best_friend')
+        self.assertEqual('best_friend', name)
+
+    def test_related_recursive_self_filter(self):
+        # see: https://github.com/philipn/django-rest-framework-filters/issues/333
+        name = PersonFilter.get_param_filter_name('best_friend', rel='best_friend')
+        self.assertEqual(None, name)
 
     def test_twice_removed_related_filter(self):
         class PostFilterWithDirectAuthor(PostFilter):


### PR DESCRIPTION
With a recursive self relationship, the untransformed relationship field was not accounted for due to not being prefixed by itself. e.g., with the test models, `best_friend__best_friend` should be passed to the `best_friend` relationship, but not the plain `best_friend` param. Because `best_friend` was passed and the relationship is circular, this caused a `RecursionError`.

Fixes #333

Test failure build: https://travis-ci.org/github/philipn/django-rest-framework-filters/builds/716051877
Fixed build: https://travis-ci.org/github/philipn/django-rest-framework-filters/builds/716052913