### PR TITLE
Adding ppc64le architecture support on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ python:
   - "3.7"
   - "3.8"
 
+arch:
+  - amd64
+  - ppc64le
+
 install:
   - travis_retry pip install -U six setuptools pip wheel
   - travis_retry pip install -U tox tox-travis coverage
@@ -33,6 +37,26 @@ matrix:
         - rm -r djangorestframework_filters.egg-info
         - tox --installpkg ./dist/djangorestframework_filters-*.whl
         - tox  # test sdist
+
+    # Adding jobs for ppc64le architecture
+    - python: "3.8"
+      arch: ppc64le
+      env: TOXENV="performance"
+      script: tox -- -v 2
+    - python: "3.8"
+      arch: ppc64le
+      env: TOXENV="warnings"
+    - python: "3.8"
+      arch: ppc64le
+      env: TOXENV="isort,lint"
+    - python: "3.8"
+      arch: ppc64le
+      env: TOXENV="dist"
+      script:
+        - python setup.py bdist_wheel
+        - rm -r djangorestframework_filters.egg-info
+        - tox --installpkg ./dist/djangorestframework_filters-*.whl
+        - tox  # test sdist   
 
   allow_failures:
     - env: TOXENV="warnings"


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/kishorkunal-raj/django-rest-framework-filters/builds/190244371

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Please take a look.

Regards,
Kishor Kunal Raj